### PR TITLE
Fix a failing test.

### DIFF
--- a/lib/slingshot/search.rb
+++ b/lib/slingshot/search.rb
@@ -88,7 +88,7 @@ module Slingshot
       end
 
       def to_curl
-        %Q|curl -X POST "#{Configuration.url}/#{indices}/_search?pretty=true" -d '#{self.to_json}'|
+        %Q|curl -X POST "#{Configuration.url}/#{indices.join(',')}/_search?pretty=true" -d '#{self.to_json}'|
       end
 
       def to_json


### PR DESCRIPTION
the Search#to_curl method didn't join the indices to convert them to a comma delimited string which caused a test to fail.
