### PR TITLE
Properties _type and _index are nil

### DIFF
--- a/lib/tire/results/collection.rb
+++ b/lib/tire/results/collection.rb
@@ -21,7 +21,7 @@ module Tire
                        document.update( {'id' => h['_id']} )
 
                        # Update the document with meta information
-                       ['_score', '_version', 'sort', 'highlight'].each { |key| document.update( {key => h[key]} || {} ) }
+                       ['_score', '_type', '_index', '_version', 'sort', 'highlight'].each { |key| document.update( {key => h[key]} || {} ) }
 
                        object = Configuration.wrapper.new(document)
                        # TODO: Figure out how to circumvent mass assignment protection for id in ActiveRecord

--- a/test/unit/results_collection_test.rb
+++ b/test/unit/results_collection_test.rb
@@ -41,7 +41,7 @@ module Tire
       context "wrapping results" do
 
         setup do
-          @response = { 'hits' => { 'hits' => [ { '_id' => 1, '_score' => 0.5, '_source' => { :title => 'Test', :body => 'Lorem' } } ] } }
+          @response = { 'hits' => { 'hits' => [ { '_id' => 1, '_score' => 0.5, '_index' => 'testing', '_type' => 'article', '_source' => { :title => 'Test', :body => 'Lorem' } } ] } }
         end
 
         should "wrap hits in Item by default" do
@@ -81,6 +81,16 @@ module Tire
         should "return id" do
           document =  Results::Collection.new(@response).first
           assert_equal 1, document.id
+        end
+
+        should "return index" do
+          document =  Results::Collection.new(@response).first
+          assert_equal "testing", document._index
+        end
+
+        should "return type" do
+          document =  Results::Collection.new(@response).first
+          assert_equal "article", document._type
         end
 
       end


### PR DESCRIPTION
Collection items have _index and _type methods, but they are nil. This commit should resolve this.
