### PR TITLE
Allow to set search options when using a query string

### DIFF
--- a/lib/tire/search/query.rb
+++ b/lib/tire/search/query.rb
@@ -18,7 +18,7 @@ module Tire
 
       def string(value, options={})
         @value = { :query_string => { :query => value } }
-        @value[:query_string].update( { :default_field => options[:default_field] } ) if options[:default_field]
+        @value[:query_string].update(options)
         # TODO: https://github.com/elasticsearch/elasticsearch/wiki/Query-String-Query
         @value
       end

--- a/test/unit/search_query_test.rb
+++ b/test/unit/search_query_test.rb
@@ -39,6 +39,11 @@ module Tire::Search
                       Query.new.string('foo', :default_field => 'title') )
       end
 
+      should "allow set options when searching with a query string" do
+        assert_equal( { :query_string => { :query => 'foo', :fields => ['title.*'], :use_dis_max => true } },
+                      Query.new.string('foo', :fields => ['title.*'], :use_dis_max => true) )
+      end
+
       should "search for all documents" do
         assert_equal( { :match_all => { } }, Query.new.all )
       end


### PR DESCRIPTION
Now its possible to set default_field option only. This commit should allow more options like fields, use_dis_max etc (http://www.elasticsearch.org/guide/reference/query-dsl/query-string-query.html)
