### PR TITLE
[Feature] Handling Selecting Inner Fields on Inner Objects

### DIFF
--- a/test/models/article.rb
+++ b/test/models/article.rb
@@ -1,7 +1,7 @@
 # Example non-ActiveModel custom wrapper for result item
 
 class Article
-  attr_reader :id, :title, :body
+  attr_reader :id, :title, :body, :inner_object
 
   def initialize(attributes={})
     attributes.each { |k,v| instance_variable_set(:"@#{k}", v) }

--- a/test/unit/results_collection_test.rb
+++ b/test/unit/results_collection_test.rb
@@ -46,7 +46,7 @@ module Tire
       context "wrapping results" do
 
         setup do
-          @response = { 'hits' => { 'hits' => [ { '_id' => 1, '_score' => 0.5, '_index' => 'testing', '_type' => 'article', '_source' => { :title => 'Test', :body => 'Lorem' } } ] } }
+          @response = { 'hits' => { 'hits' => [ { '_id' => 1, '_score' => 0.5, '_index' => 'testing', '_type' => 'article', '_source' => { :title => 'Test', :body => 'Lorem'} } ] } }
         end
 
         should "wrap hits in Item by default" do
@@ -76,6 +76,24 @@ module Tire
           article =  Results::Collection.new(@response).first
           assert_kind_of Article, article
           assert_equal   'Test',  article.title
+        end
+        
+        should "allow wrapping hits in custom class" do
+          Configuration.wrapper(Article)
+
+          article =  Results::Collection.new(@response).first
+          assert_kind_of Article, article
+          assert_equal   'Test',  article.title
+        end
+
+        should "inner _source objects in hits should be properly wrapped in custom class" do
+          @response = { 'hits' => { 'hits' => [ { '_id' => 1, '_score' => 0.5, '_index' => 'testing', '_type' => 'article', 'fields' => {'_source.inner_object.a' => 1, '_source.inner_object.b.c' => 2} } ] } }
+          Configuration.wrapper(Article)
+
+          article =  Results::Collection.new(@response).first
+          assert_kind_of Article, article
+          assert_equal   1,  article.inner_object['a']
+          assert_equal   2,  article.inner_object['b']['c']
         end
 
         should "return score" do

--- a/test/unit/results_collection_test.rb
+++ b/test/unit/results_collection_test.rb
@@ -78,14 +78,6 @@ module Tire
           assert_equal   'Test',  article.title
         end
         
-        should "allow wrapping hits in custom class" do
-          Configuration.wrapper(Article)
-
-          article =  Results::Collection.new(@response).first
-          assert_kind_of Article, article
-          assert_equal   'Test',  article.title
-        end
-
         should "inner _source objects in hits should be properly wrapped in custom class" do
           @response = { 'hits' => { 'hits' => [ { '_id' => 1, '_score' => 0.5, '_index' => 'testing', '_type' => 'article', 'fields' => {'_source.inner_object.a' => 1, '_source.inner_object.b.c' => 2} } ] } }
           Configuration.wrapper(Article)


### PR DESCRIPTION
[Feature] When selecting specific fields on an inner object, Elasticsearch returns the inner fields in this format '_source.inner_object', '_source.inner_object.inner_key'. I need this behaviour to be properly handled in my app, as I have some large keys I do not want to serialize on inner object, so I like cherry-picking them, I've added handling for this syntax.

Here's an example of the underlying Elastic search request:

curl -X POST "http://localhost:9200/foo-attachments-index/_search?pretty=true" -d '{"size":5,"from":0,"fields":["uuid","hash","file_extension","file_size","filename","type","external_id","downloadable","date","sender","visible","thumbnail_created","shared","large_thumbnail_created","share_url","meta","_source.meta.image_width"],"sort":["_score"],"query":{"bool":{"must":[{"query_string":{"query":"*"}},{"term":{"user_uuid":"foo"}}]}}}'
