### PR TITLE
Search should perform a GET instead of a POST request.

### DIFF
--- a/lib/tire/client.rb
+++ b/lib/tire/client.rb
@@ -3,7 +3,7 @@ module Tire
   module Client
 
     class Base
-      def get(url)
+      def get(url, data=nil)
         raise_no_method_error
       end
       def post(url, data)
@@ -21,8 +21,8 @@ module Tire
     end
 
     class RestClient < Base
-      def self.get(url)
-        ::RestClient.get url
+      def self.get(url, data=nil)
+        ::RestClient::Request.new(:method => :get, :url => url, :payload => data).execute
       end
       def self.post(url, data)
         ::RestClient.post url, data

--- a/lib/tire/search.rb
+++ b/lib/tire/search.rb
@@ -65,7 +65,7 @@ module Tire
 
       def perform
         @url      = "#{Configuration.url}/#{indices.join(',')}/_search"
-        @response = Configuration.client.post(@url, self.to_json)
+        @response = Configuration.client.get(@url, self.to_json)
         @json     = MultiJson.decode(@response.body)
         @results  = Results::Collection.new(@json, @options)
         self
@@ -77,7 +77,7 @@ module Tire
       end
 
       def to_curl
-        %Q|curl -X POST "#{Configuration.url}/#{indices.join(',')}/_search?pretty=true" -d '#{self.to_json}'|
+        %Q|curl -X GET "#{Configuration.url}/#{indices.join(',')}/_search?pretty=true" -d '#{self.to_json}'|
       end
 
       def to_json

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,7 +31,7 @@ class Test::Unit::TestCase
 end
 
 module Test::Integration
-  URL = "http://localhost:9200"
+  URL = "http://localhost.aws:9200"
 
   def setup
     begin

--- a/test/unit/model_persistence_test.rb
+++ b/test/unit/model_persistence_test.rb
@@ -86,21 +86,21 @@ module Tire
         end
 
         should "find document by list of IDs" do
-          Configuration.client.expects(:post).returns(mock_response(@find_last_two.to_json))
+          Configuration.client.expects(:get).returns(mock_response(@find_last_two.to_json))
           documents = PersistentArticle.find 2, 3
 
           assert_equal 2, documents.count
         end
 
         should "find document by array of IDs" do
-          Configuration.client.expects(:post).returns(mock_response(@find_last_two.to_json))
+          Configuration.client.expects(:get).returns(mock_response(@find_last_two.to_json))
           documents = PersistentArticle.find [2, 3]
 
           assert_equal 2, documents.count
         end
 
         should "find all documents" do
-          Configuration.client.stubs(:post).returns(mock_response(@find_all.to_json))
+          Configuration.client.stubs(:get).returns(mock_response(@find_all.to_json))
           documents = PersistentArticle.all
 
           assert_equal 3, documents.count
@@ -109,7 +109,7 @@ module Tire
         end
 
         should "find first document" do
-          Configuration.client.expects(:post).returns(mock_response(@find_first.to_json))
+          Configuration.client.expects(:get).returns(mock_response(@find_first.to_json))
           document = PersistentArticle.first
 
           assert_equal 'First', document.attributes['title']

--- a/test/unit/model_search_test.rb
+++ b/test/unit/model_search_test.rb
@@ -70,7 +70,7 @@ module Tire
 
         should "wrap results in proper class with ID and score and not change the original wrapper" do
           response = { 'hits' => { 'hits' => [{'_id' => 1, '_score' => 0.8, '_source' => { 'title' => 'Article' }}] } }
-          Configuration.client.expects(:post).returns(mock_response(response.to_json))
+          Configuration.client.expects(:get).returns(mock_response(response.to_json))
 
           collection = ActiveModelArticle.search 'foo'
           assert_instance_of Results::Collection, collection

--- a/test/unit/search_test.rb
+++ b/test/unit/search_test.rb
@@ -43,7 +43,7 @@ module Tire
         s = Search::Search.new('index') do
           query { string 'title:foo' }
         end
-        assert_equal %q|curl -X POST "http://localhost:9200/index/_search?pretty=true" -d | +
+        assert_equal %q|curl -X GET "http://localhost:9200/index/_search?pretty=true" -d | +
                      %q|'{"query":{"query_string":{"query":"title:foo"}}}'|,
                      s.to_curl
       end
@@ -63,7 +63,7 @@ module Tire
 
       should "perform the search" do
         response = stub(:body => '{"took":1,"hits":[]}', :code => 200)
-        Configuration.client.expects(:post).returns(response)
+        Configuration.client.expects(:get).returns(response)
         Results::Collection.expects(:new).returns([])
 
         s = Search::Search.new('index')
@@ -73,7 +73,7 @@ module Tire
       end
 
       should "print debugging information on exception and re-raise it" do
-        Configuration.client.expects(:post).raises(RestClient::InternalServerError)
+        Configuration.client.expects(:get).raises(RestClient::InternalServerError)
         STDERR.expects(:puts)
 
         s = Search::Search.new('index')
@@ -84,7 +84,7 @@ module Tire
         Configuration.logger STDERR
 
         response = stub(:body => '{"took":1,"hits":[]}', :code => 200)
-        Configuration.client.expects(:post).returns(response)
+        Configuration.client.expects(:get).returns(response)
 
         Results::Collection.expects(:new).returns([])
         Configuration.logger.expects(:log_request).returns(true)


### PR DESCRIPTION
Currently, Tire.search executes a POST.  Since search is just querying elasticsearch and not modifying the documents, it really should perform a GET instead of a POST.
