### PR TITLE
Populate results collection lazily & fixed two TODOs

### DIFF
--- a/lib/tire/results/collection.rb
+++ b/lib/tire/results/collection.rb
@@ -5,49 +5,56 @@ module Tire
       include Enumerable
       include Pagination
 
-      attr_reader :time, :total, :options, :results, :facets
+      attr_reader :time, :total, :options, :facets
 
       def initialize(response, options={})
-        @options = options
-        @time    = response['took'].to_i
-        @total   = response['hits']['total'].to_i
-        @results = response['hits']['hits'].map do |h|
-                     if Configuration.wrapper == Hash then h
-                     else
-                       document = {}
+        @response = response
+        @options  = options
+        @time     = response['took'].to_i
+        @total    = response['hits']['total'].to_i
+        @facets   = response['facets']
+        @wrapper  = Configuration.wrapper
+      end
 
-                       # Update the document with content and ID
-                       document = h['_source'] ? document.update( h['_source'] || {} ) : document.update( h['fields'] || {} )
-                       document.update( {'id' => h['_id']} )
+      def results
+        @results ||= begin
+          @response['hits']['hits'].map do |h|
+             if @wrapper == Hash then h
+             else
+               document = {}
 
-                       # Update the document with meta information
-                       ['_score', '_type', '_index', '_version', 'sort', 'highlight'].each { |key| document.update( {key => h[key]} || {} ) }
+               # Update the document with content and ID
+               document = h['_source'] ? document.update( h['_source'] || {} ) : document.update( h['fields'] || {} )
+               document.update( {'id' => h['_id']} )
 
-                       object = Configuration.wrapper.new(document)
-                       # TODO: Figure out how to circumvent mass assignment protection for id in ActiveRecord
-                       object.id = h['_id'] if object.respond_to?(:id=)
-                       # TODO: Figure out how mark record as "not new record" in ActiveRecord
-                       object.instance_variable_set(:@new_record, false) if object.respond_to?(:new_record?)
-                       object
-                     end
-                   end
-        @facets  = response['facets']
+               # Update the document with meta information
+               ['_score', '_type', '_index', '_version', 'sort', 'highlight'].each { |key| document.update( {key => h[key]} || {} ) }
+
+               object = @wrapper.new(document)
+               # TODO: Figure out how to circumvent mass assignment protection for id in ActiveRecord
+               object.id = h['_id'] if object.respond_to?(:id=)
+               # TODO: Figure out how mark record as "not new record" in ActiveRecord
+               object.instance_variable_set(:@new_record, false) if object.respond_to?(:new_record?)
+               object
+             end
+           end
+        end
       end
 
       def each(&block)
-        @results.each(&block)
+        results.each(&block)
       end
 
       def empty?
-        @results.empty?
+        results.empty?
       end
 
       def size
-        @results.size
+        results.size
       end
 
       def [](index)
-        @results[index]
+        results[index]
       end
 
       def to_ary

--- a/lib/tire/results/collection.rb
+++ b/lib/tire/results/collection.rb
@@ -25,17 +25,15 @@ module Tire
 
                # Update the document with content and ID
                document = h['_source'] ? document.update( h['_source'] || {} ) : document.update( h['fields'] || {} )
+               document.update( {'id' => h['_id']} )
 
                # Update the document with meta information
                ['_score', '_type', '_index', '_version', 'sort', 'highlight'].each { |key| document.update( {key => h[key]} || {} ) }
 
                # for instantiating ActiveRecord with arbitrary attributes and setting @new_record etc.
                if @wrapper.respond_to?(:instantiate, true)
-                 object = @wrapper.send(:instantiate, document)
-                 object.id = h['_id'] if object.respond_to?(:id=)
-                 object
+                 @wrapper.send(:instantiate, document)
                else
-                 document.update( {'id' => h['_id']} )
                  @wrapper.new(document)
                end
              end

--- a/test/unit/results_collection_test.rb
+++ b/test/unit/results_collection_test.rb
@@ -37,6 +37,11 @@ module Tire
         end
       end
 
+      should "be populated lazily" do
+        collection = Results::Collection.new(@default_response)
+        assert_nil collection.instance_variable_get(:@results)
+      end
+
       should "store passed options" do
         collection = Results::Collection.new( @default_response, :per_page => 20, :page => 2 )
         assert_equal 20, collection.options[:per_page]


### PR DESCRIPTION
Hey Karel,

I've noticed that results are iterated automatically when the results collection is instantiated. IMO this should be done lazily because this allows better performance if – for whichever reason – you're not interested in the results but just the meta data and/or facets (I have the latter use case in an app that's currently using Thinking Sphinx).

If you prefer a more declarative approach, I could certainly implement it similarly to TS (i.e. a populate method and a populated? predicate).

Cheers,
- Clemens
