### PR TITLE
Fixed bad calls to MultiJson.encode when logging on 'debug' level

### DIFF
--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -275,7 +275,7 @@ module Tire
 
         if Configuration.logger.level.to_s == 'debug'
           # FIXME: Depends on RestClient implementation
-          body = @response ? MultiJson.encode(@response.body, :pretty => true) : error.http_body rescue ''
+          body = @response ? MultiJson.encode(MultiJson.decode(@response.body).merge(:pretty => true)) : error.http_body rescue ''
         else
           body = ''
         end

--- a/lib/tire/search.rb
+++ b/lib/tire/search.rb
@@ -107,7 +107,7 @@ module Tire
 
           if Configuration.logger.level.to_s == 'debug'
             # FIXME: Depends on RestClient implementation
-            body = @response ? MultiJson.encode(@json, :pretty => true) : body = error.http_body
+            body = @response ? MultiJson.encode(@json.merge(:pretty => true)) : body = error.http_body
           else
             body = ''
           end


### PR DESCRIPTION
Fixed bad calls to MultiJson.encode when logging on 'debug' level (see https://gist.github.com/6a948b75f27ba140eeca for an example of the error raised by calling incorrectly).
