### PR TITLE
ActiveModel integration should search in <INDEX>/<TYPE>

### DIFF
--- a/lib/tire/model/search.rb
+++ b/lib/tire/model/search.rb
@@ -37,7 +37,7 @@ module Tire
           Tire::Configuration.wrapper self
           sort  = Array( options[:order] || options[:sort] )
           unless block_given?
-            s = Tire::Search::Search.new(elasticsearch_index.name, options)
+            s = Tire::Search::Search.new(elasticsearch_index.name, options.merge(:type => document_type))
             s.query { string query }
             s.sort do
               sort.each do |t|

--- a/test/unit/model_search_test.rb
+++ b/test/unit/model_search_test.rb
@@ -51,30 +51,32 @@ module Tire
         should_eventually "NOT overload existing top-level instance methods" do
         end
 
-        should "search in index named after class name by default" do
-          i = 'active_model_articles'
-          Tire::Search::Search.expects(:new).with(i, {}).returns(@stub)
+        should "search only in index named after class name and document types for this class by default" do
+          Tire::Search::Search.expects(:new).
+            with(ActiveModelArticle.index_name,
+                 { :type => ActiveModelArticle.document_type }).
+            returns(@stub)
 
           ActiveModelArticle.search 'foo'
-        end
-
-        should_eventually "search only in document types for this class by default" do
         end
 
         should "search in custom name" do
           first  = 'custom-index-name'
           second = 'another-custom-index-name'
+          expected_options = {
+            :type => ActiveModelArticleWithCustomIndexName.document_type
+          }
 
-          Tire::Search::Search.expects(:new).with(first, {}).returns(@stub)
-          ActiveModelArticleWithCustomIndexName.index_name 'custom-index-name'
+          Tire::Search::Search.expects(:new).with(first, expected_options).returns(@stub)
+          ActiveModelArticleWithCustomIndexName.index_name first
           ActiveModelArticleWithCustomIndexName.search 'foo'
 
-          Tire::Search::Search.expects(:new).with(second, {}).returns(@stub)
-          ActiveModelArticleWithCustomIndexName.index_name 'another-custom-index-name'
+          Tire::Search::Search.expects(:new).with(second, expected_options).returns(@stub)
+          ActiveModelArticleWithCustomIndexName.index_name second
           ActiveModelArticleWithCustomIndexName.search 'foo'
 
-          Tire::Search::Search.expects(:new).with(first, {}).returns(@stub)
-          ActiveModelArticleWithCustomIndexName.index_name 'custom-index-name'
+          Tire::Search::Search.expects(:new).with(first, expected_options).returns(@stub)
+          ActiveModelArticleWithCustomIndexName.index_name first
           ActiveModelArticleWithCustomIndexName.search 'foo'
         end
 


### PR DESCRIPTION
Added ability to pass type to search. Model passes document_type to search. #38
