### PR TITLE
I've adjusted Model::Search#search to allow for options to be passed in when called with a block

### DIFF
--- a/lib/tire/model/search.rb
+++ b/lib/tire/model/search.rb
@@ -32,7 +32,14 @@ module Tire
 
       module ClassMethods
 
-        def search(query=nil, options={}, &block)
+        # Usage:
+        #
+        # search('query', [options])
+        # search([options]) do <block> end
+        def search(*args, &block)
+          query = args.size >= 1 ? args[0] : nil
+          options = args.size > 0 ? (args.last.respond_to?(:keys) ? args.last : {}) : {}
+
           old_wrapper = Tire::Configuration.wrapper
           Tire::Configuration.wrapper self
 

--- a/lib/tire/model/search.rb
+++ b/lib/tire/model/search.rb
@@ -39,8 +39,10 @@ module Tire
           sort    = Array( options[:order] || options[:sort] )
           options = {:type => document_type}.update(options)
 
+          s = Tire::Search::Search.new(elasticsearch_index.name, options)
+          s.size( options[:per_page].to_i ) if options[:per_page]
+          s.from( options[:page].to_i <= 1 ? 0 : (options[:per_page].to_i * (options[:page].to_i-1)) ) if options[:page] && options[:per_page]
           unless block_given?
-            s = Tire::Search::Search.new(elasticsearch_index.name, options)
             s.query { string query }
             s.sort do
               sort.each do |t|
@@ -48,14 +50,10 @@ module Tire
                 by field_name, direction
               end
             end unless sort.empty?
-            s.size( options[:per_page].to_i ) if options[:per_page]
-            s.from( options[:page].to_i <= 1 ? 0 : (options[:per_page].to_i * (options[:page].to_i-1)) ) if options[:page] && options[:per_page]
-            s.perform.results
           else
-            s = Tire::Search::Search.new(elasticsearch_index.name, options)
             block.arity < 1 ? s.instance_eval(&block) : block.call(s)
-            s.perform.results
           end
+          s.perform.results
         ensure
           Tire::Configuration.wrapper old_wrapper
         end

--- a/test/unit/model_search_test.rb
+++ b/test/unit/model_search_test.rb
@@ -189,6 +189,17 @@ module Tire
             ActiveModelArticle.search @q, :per_page => 10, :page => 3
           end
 
+          should "allow to specify page even if using a block" do
+            Tire::Search::Search.any_instance.expects(:size).with(10)
+            Tire::Search::Search.any_instance.expects(:from).with(20)
+
+            ActiveModelArticle.search :per_page => 10, :page => 3 do
+              query do
+                string 'foo AND bar' #@q is not visible here
+              end
+            end
+          end
+
         end
 
         should "not set callback when hooks are missing" do


### PR DESCRIPTION
Cleaned up the code to remove duplicate lines whether calling with or without a block
Changed the method signature so it can be called in a number of ways

search('query', [options])
search <block>
search [options] <block>

eliminates: search nil, [options] <block>

Also moved the pagination code to be used whether calling with or without a block.
