### PR TITLE
Should force a type to be specified. This bit me in the ass. 

### DIFF
--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -280,7 +280,8 @@ module Tire
           document.type
         end
       $VERBOSE = old_verbose
-      type ||= :document
+      raise "Please specify a type" unless type
+      type
     end
 
     def get_id_from_document(document)


### PR DESCRIPTION
I was very confused why my term search wasn't working. What I created for an index was different then where it was being stored. If there was no default I could have detected this error in my hash earlier. 

Thanks 
Becker
