### PR TITLE
Removed ?pretty=true

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -292,7 +292,7 @@ Or, better, we can display the corresponding `curl` command to recreate and debu
 
 ```ruby
     puts s.to_curl
-    # curl -X POST "http://localhost:9200/articles/_search?pretty=true" -d '{"facets":{"current-tags":{"terms":{"field":"tags"}},"global-tags":{"global":true,"terms":{"field":"tags"}}},"query":{"query_string":{"query":"title:T*"}},"filter":{"terms":{"tags":["ruby"]}},"sort":[{"title":"desc"}]}'
+    # curl -X POST "http://localhost:9200/articles/_search" -d '{"facets":{"current-tags":{"terms":{"field":"tags"}},"global-tags":{"global":true,"terms":{"field":"tags"}}},"query":{"query_string":{"query":"title:T*"}},"filter":{"terms":{"tags":["ruby"]}},"sort":[{"title":"desc"}]}'
 ```
 
 However, we can simply log every search query (and other requests) in this `curl`-friendly format:

--- a/examples/tire-dsl.rb
+++ b/examples/tire-dsl.rb
@@ -297,7 +297,7 @@ puts s.to_json
 # Or better yet, we may display a complete `curl` command to recreate the request in terminal,
 # so we can see the naked response, tweak request parameters and meditate on problems.
 #
-#     curl -X POST "http://localhost:9200/articles/_search?pretty=true" \
+#     curl -X POST "http://localhost:9200/articles/_search" \
 #          -d '{"query":{"query_string":{"query":"title:T*"}}}'
 #
 puts "", "Try the query in Curl:", "-"*80

--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -190,7 +190,7 @@ module Tire
       rescue Exception => error
         raise
       ensure
-        curl = %Q|curl -X PUT "#{Configuration.url}/_percolator/#{@name}/?pretty=1" -d '#{MultiJson.encode(options)}'|
+        curl = %Q|curl -X PUT "#{Configuration.url}/_percolator/#{@name}" -d '#{MultiJson.encode(options)}'|
         logged(error, '_percolator', curl)
     end
 
@@ -221,7 +221,7 @@ module Tire
       rescue Exception => error
         # raise
       ensure
-        curl = %Q|curl -X GET "#{Configuration.url}/#{@name}/#{type}/_percolate?pretty=1" -d '#{payload.to_json}'|
+        curl = %Q|curl -X GET "#{Configuration.url}/#{@name}/#{type}/_percolate" -d '#{payload.to_json}'|
         logged(error, '_percolate', curl)
     end
 
@@ -235,7 +235,7 @@ module Tire
         if Configuration.logger.level.to_s == 'debug'
           # FIXME: Depends on RestClient implementation
           body = if @response
-            defined?(Yajl) ? Yajl::Encoder.encode(@json, :pretty => true) : MultiJson.encode(@json)
+            defined?(Yajl) ? Yajl::Encoder.encode(@json) : MultiJson.encode(@json)
           else
             error.http_body rescue ''
           end

--- a/lib/tire/search.rb
+++ b/lib/tire/search.rb
@@ -79,7 +79,7 @@ module Tire
       end
 
       def to_curl
-        %Q|curl -X GET "#{@url}?pretty=true" -d '#{self.to_json}'|
+        %Q|curl -X GET "#{@url}" -d '#{self.to_json}'|
       end
 
       def to_hash
@@ -110,7 +110,7 @@ module Tire
           if Configuration.logger.level.to_s == 'debug'
             # FIXME: Depends on RestClient implementation
             body = if @response
-              defined?(Yajl) ? Yajl::Encoder.encode(@json, :pretty => true) : MultiJson.encode(@json)
+              defined?(Yajl) ? Yajl::Encoder.encode(@json) : MultiJson.encode(@json)
             else
               error.http_body rescue ''
             end

--- a/lib/tire/tasks.rb
+++ b/lib/tire/tasks.rb
@@ -52,7 +52,7 @@ namespace :tire do
     end
 
     unless index.exists?
-      mapping = defined?(Yajl) ? Yajl::Encoder.encode(klass.mapping_to_hash, :pretty => true) :
+      mapping = defined?(Yajl) ? Yajl::Encoder.encode(klass.mapping_to_hash) :
                                  MultiJson.encode(klass.mapping_to_hash)
       puts "[IMPORT] Creating index '#{index.name}' with mapping:", mapping
       index.create :mappings => klass.mapping_to_hash

--- a/test/unit/search_test.rb
+++ b/test/unit/search_test.rb
@@ -67,7 +67,7 @@ module Tire
         s = Search::Search.new('index') do
           query { string 'title:foo' }
         end
-        assert_equal %q|curl -X GET "http://localhost:9200/index/_search?pretty=true" -d | +
+        assert_equal %q|curl -X GET "http://localhost:9200/index/_search" -d | +
                      %q|'{"query":{"query_string":{"query":"title:foo"}}}'|,
                      s.to_curl
       end


### PR DESCRIPTION
`?pretty=true` should only be used for debugging. Removed.
(http://www.elasticsearch.org/guide/reference/api/)
