### PR TITLE
[Feature] ActiveRecord integration: index_name can now optionally be passed in to a search. 

### DIFF
--- a/lib/tire/model/search.rb
+++ b/lib/tire/model/search.rb
@@ -71,8 +71,13 @@ module Tire
 
           sort      = Array( options[:order] || options[:sort] )
           options   = default_options.update(options)
-
-          s = Tire::Search::Search.new(elasticsearch_index.name, options)
+          
+          if options.fetch(:index_name, nil)
+            s = Tire::Search::Search.new(options.delete(:index_name), options)
+          else
+            s = Tire::Search::Search.new(elasticsearch_index.name, options)
+          end
+          
           s.size( options[:per_page].to_i ) if options[:per_page]
           s.from( options[:page].to_i <= 1 ? 0 : (options[:per_page].to_i * (options[:page].to_i-1)) ) if options[:page] && options[:per_page]
           s.sort do

--- a/test/models/active_record_models.rb
+++ b/test/models/active_record_models.rb
@@ -40,6 +40,9 @@ class ActiveRecordArticle < ActiveRecord::Base
   end
 end
 
+class CustomActiveRecordArticle < ActiveRecordArticle
+end
+
 class ActiveRecordComment < ActiveRecord::Base
   belongs_to :article, :class_name => "ActiveRecordArticle", :foreign_key => "article_id"
 end


### PR DESCRIPTION
It's nice to be able to override the :index_name on a query by query basis. this allows for an ActiveRecord class to interact with multiple indices without race conditions (since the variable index_name is set as a class level variable).

This solves a problem I ran into when an application might have multiple indices being interacted with on the same ActiceRecord model. It's nice to be able to specify an index at search time.
