### PR TITLE
[ACTIVEMODEL] allow to set per-instance custom index name.

### DIFF
--- a/lib/tire/model/naming.rb
+++ b/lib/tire/model/naming.rb
@@ -15,8 +15,9 @@ module Tire
       end
 
       module InstanceMethods
-        def index_name
-          instance.class.tire.index_name
+        def index_name name=nil
+          @index_name = name if name
+          @index_name || instance.class.tire.index_name
         end
 
         def document_type

--- a/test/unit/model_search_test.rb
+++ b/test/unit/model_search_test.rb
@@ -92,6 +92,14 @@ module Tire
           end
         end
 
+        should "allow to set per-instance custom index name" do
+          ActiveModelArticle.index_name "class-index-name"
+          instance = ActiveModelArticle.new
+          instance.index_name "instance-index-name"
+          assert_equal "instance-index-name", instance.index_name
+          assert_equal "class-index-name", ActiveModelArticle.index_name
+        end
+
         should "allow to refresh index" do
           Index.any_instance.expects(:refresh)
 


### PR DESCRIPTION
This is useful, for instance, to set a custom index name from the model instance attributes before the update_index callback in a safe way.
