### PR TITLE
Support for an index prefix for easy multi-environment support (test, development, production etc.)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ scratch/
 examples/*.html
 *.log
 .rvmrc
+.redcar

--- a/README.markdown
+++ b/README.markdown
@@ -356,7 +356,7 @@ When you now save a record:
                    :published_on => Time.now
 ```
 
-it is automatically added into the index, because of the included callbacks.
+it is automatically added into an index called 'articles', because of the included callbacks.
 (You may want to skip them in special cases, like when your records are indexed via some external
 mechanism, let's say a _CouchDB_ or _RabbitMQ_
 [river](http://www.elasticsearch.org/blog/2010/09/28/the_river.html).
@@ -686,6 +686,17 @@ To use the persistence features, just include the `Tire::Persistence` module in 
 Of course, not all validations or `ActionPack` helpers will be available to your models,
 but if you can live with that, you've just got a schema-free, highly-scalable storage
 and retrieval engine for your data.
+
+If you are using persistence features and thus using ES instead of a database, you may want to separate your indexes based on your environments.
+You can do so by configuring an index_prefix that will be used to prefix the default index names. 
+
+Add to your initializers a similar snippet to the following:
+
+```ruby
+    Tire.configure { index_prefix "#{Rails.env.to_s.downcase}_" }
+```
+
+This will result in Article instances being stored in an index called 'test_articles' when used in tests but in the index 'development_articles' when used in the development environment.
 
 Please be sure to peruse the [integration test suite](https://github.com/karmi/tire/tree/master/test/integration)
 for examples of the API and _ActiveModel_ integration usage.

--- a/lib/tire/configuration.rb
+++ b/lib/tire/configuration.rb
@@ -6,6 +6,10 @@ module Tire
       @url    = (value ? value.to_s.gsub(%r|/*$|, '') : nil) || @url || "http://localhost:9200"
     end
 
+    def self.index_prefix(index_prefix = nil)
+      @index_prefix = index_prefix || @index_prefix || nil
+    end
+
     def self.client(klass=nil)
       @client = klass || @client || Client::RestClient
     end

--- a/lib/tire/model/naming.rb
+++ b/lib/tire/model/naming.rb
@@ -19,7 +19,7 @@ module Tire
         #
         def index_name name=nil
           @index_name = name if name
-          @index_name || klass.model_name.plural
+          @index_name || "#{Tire::Configuration.index_prefix.nil? ? '' : Tire::Configuration.index_prefix}#{klass.model_name.plural}"
         end
 
         # Get the document type for this model, based on the class name.

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -12,6 +12,7 @@ module Tire
       setup do
         Configuration.instance_variable_set(:@url,    nil)
         Configuration.instance_variable_set(:@client, nil)
+        Configuration.instance_variable_set(:@index_prefix, nil)
       end
 
       teardown do
@@ -46,20 +47,36 @@ module Tire
         assert_instance_of Tire::Logger, Configuration.logger
       end
 
-      should "allow to reset the configuration for specific property" do
+      should "return default nil index prefix" do
+        assert_nil Configuration.index_prefix
+      end
+
+      should "allow setting and retrieving the index prefix" do
+        assert_nothing_raised { Configuration.index_prefix 'app_environment_' }
+        assert_equal 'app_environment_', Configuration.index_prefix
+      end
+
+      should "allow to reset the configuration for specific property, and does not affect others" do
         Configuration.url 'http://example.com'
+        Configuration.index_prefix 'app_environment_'
         assert_equal      'http://example.com', Configuration.url
+        assert_equal 'app_environment_', Configuration.index_prefix
         Configuration.reset :url
         assert_equal      'http://localhost:9200', Configuration.url
+        assert_equal 'app_environment_', Configuration.index_prefix
       end
 
       should "allow to reset the configuration for all properties" do
         Configuration.url     'http://example.com'
+        Configuration.index_prefix 'app_environment_'
         Configuration.wrapper Hash
         assert_equal          'http://example.com', Configuration.url
+        assert_equal 'app_environment_', Configuration.index_prefix
         Configuration.reset
         assert_equal          'http://localhost:9200', Configuration.url
         assert_equal          Client::RestClient, Configuration.client
+        assert_nil Configuration.index_prefix
+        
       end
     end
 

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -60,10 +60,10 @@ module Tire
         Configuration.url 'http://example.com'
         Configuration.index_prefix 'app_environment_'
         assert_equal      'http://example.com', Configuration.url
-        assert_equal 'app_environment_', Configuration.index_prefix
+        assert_equal      'app_environment_', Configuration.index_prefix
         Configuration.reset :url
         assert_equal      'http://localhost:9200', Configuration.url
-        assert_equal 'app_environment_', Configuration.index_prefix
+        assert_equal      'app_environment_', Configuration.index_prefix
       end
 
       should "allow to reset the configuration for all properties" do
@@ -71,7 +71,7 @@ module Tire
         Configuration.index_prefix 'app_environment_'
         Configuration.wrapper Hash
         assert_equal          'http://example.com', Configuration.url
-        assert_equal 'app_environment_', Configuration.index_prefix
+        assert_equal          'app_environment_', Configuration.index_prefix
         Configuration.reset
         assert_equal          'http://localhost:9200', Configuration.url
         assert_equal          Client::RestClient, Configuration.client

--- a/test/unit/model_persistence_test.rb
+++ b/test/unit/model_persistence_test.rb
@@ -20,6 +20,23 @@ module Tire
           assert_equal 'another-index-name', PersistentArticleWithCustomIndexName.index.name
         end
 
+        context "with index_prefix configured" do
+          setup do
+            PersistentArticle.instance_variable_set(:@index_name, nil)
+            Tire::Configuration.index_prefix 'prefix_'
+          end
+          
+          teardown do
+            Tire::Configuration.reset(:index_prefix)
+          end
+          
+          should "have configured prefix in index_name" do
+            assert_equal 'prefix_persistent_articles', PersistentArticle.index_name
+            assert_equal 'prefix_persistent_articles', PersistentArticle.new(:title => 'Test').index_name
+          end
+          
+        end
+
         should "have document_type" do
           assert_equal 'persistent_article', PersistentArticle.document_type
           assert_equal 'persistent_article', PersistentArticle.new(:title => 'Test').document_type


### PR DESCRIPTION
This change is a simple solution, similar to couchrest_model's approach, that allows setting a prefix for all automatically generated index names. 

This setting _only_ affects default index names that have not been overridden by a custom index name.

Furthermore, the default behaviour is no prefix, so it will not affect existing codebases.

One potential usage is a per-environment prefix, configured like so:
`Tire.configure { index_prefix "#{Rails.env.to_s.downcase}_" }`

This will result in a 'test_articles' index for Article instances when used in tests, and 'development_articles' when used in development.

This change includes:
- Tests
- Tiny amount of code changes 
- Usage info in README.markdown 

I hope you accept it into master :)

Cheers,
Tal
