### PR TITLE
Support for an index prefix for easy multi-environment support (test, development, production etc.) based in Model::Search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ scratch/
 examples/*.html
 *.log
 .rvmrc
+.redcar

--- a/README.markdown
+++ b/README.markdown
@@ -693,7 +693,7 @@ You can do so by configuring an index_prefix that will be used to prefix the def
 Add to your initializers a similar snippet to the following:
 
 ```ruby
-    Model::Search.index_prefix "#{Rails.env.to_s.downcase}_"
+    Tire::Model::Search.index_prefix "#{Rails.env.to_s.downcase}_"
 ```
 
 This will result in Article instances being stored in an index called 'test_articles' when used in tests but in the index 'development_articles' when used in the development environment.

--- a/README.markdown
+++ b/README.markdown
@@ -356,7 +356,7 @@ When you now save a record:
                    :published_on => Time.now
 ```
 
-it is automatically added into the index, because of the included callbacks.
+it is automatically added into an index called 'articles', because of the included callbacks.
 (You may want to skip them in special cases, like when your records are indexed via some external
 mechanism, let's say a _CouchDB_ or _RabbitMQ_
 [river](http://www.elasticsearch.org/blog/2010/09/28/the_river.html).
@@ -686,6 +686,17 @@ To use the persistence features, just include the `Tire::Persistence` module in 
 Of course, not all validations or `ActionPack` helpers will be available to your models,
 but if you can live with that, you've just got a schema-free, highly-scalable storage
 and retrieval engine for your data.
+
+If you are using persistence features and thus using ES instead of a database, you may want to separate your indexes based on your environments.
+You can do so by configuring an index_prefix that will be used to prefix the default index names. 
+
+Add to your initializers a similar snippet to the following:
+
+```ruby
+    Model::Search.index_prefix "#{Rails.env.to_s.downcase}_"
+```
+
+This will result in Article instances being stored in an index called 'test_articles' when used in tests but in the index 'development_articles' when used in the development environment.
 
 Please be sure to peruse the [integration test suite](https://github.com/karmi/tire/tree/master/test/integration)
 for examples of the API and _ActiveModel_ integration usage.

--- a/lib/tire/model/naming.rb
+++ b/lib/tire/model/naming.rb
@@ -19,7 +19,7 @@ module Tire
         #
         def index_name name=nil
           @index_name = name if name
-          @index_name || klass.model_name.plural
+          @index_name || "#{Model::Search.index_prefix.nil? ? '' : Model::Search.index_prefix}#{klass.model_name.plural}"
         end
 
         # Get the document type for this model, based on the class name.

--- a/lib/tire/model/search.rb
+++ b/lib/tire/model/search.rb
@@ -19,6 +19,14 @@ module Tire
     #
     module Search
 
+      # Model::Search specific settings
+      #
+      
+      # Sets a prefix for default index names
+      def self.index_prefix(index_prefix = nil)
+        @index_prefix = index_prefix || @index_prefix || nil
+      end
+
       module ClassMethods
 
         # Returns search results for a given query.
@@ -267,6 +275,7 @@ module Tire
         Results::Item.send :include, Loader
       end
 
+      
     end
 
   end

--- a/test/unit/model_persistence_test.rb
+++ b/test/unit/model_persistence_test.rb
@@ -20,6 +20,24 @@ module Tire
           assert_equal 'another-index-name', PersistentArticleWithCustomIndexName.index.name
         end
 
+        context "with index_prefix configured" do
+          setup do
+            PersistentArticle.instance_variable_set(:@index_name, nil)
+            Model::Search.index_prefix 'prefix_'
+          end
+          
+          teardown do
+            Model::Search.instance_variable_set(:@index_prefix, nil)
+            PersistentArticle.instance_variable_set(:@index_name, nil)
+          end
+          
+          should "have configured prefix in index_name" do
+            assert_equal 'prefix_persistent_articles', PersistentArticle.index_name
+            assert_equal 'prefix_persistent_articles', PersistentArticle.new(:title => 'Test').index_name
+          end
+          
+        end
+
         should "have document_type" do
           assert_equal 'persistent_article', PersistentArticle.document_type
           assert_equal 'persistent_article', PersistentArticle.new(:title => 'Test').document_type

--- a/test/unit/model_search_test.rb
+++ b/test/unit/model_search_test.rb
@@ -659,6 +659,23 @@ module Tire
 
       end
 
+      context "#index_prefix" do
+        
+        should "return nil by default" do
+          assert_nil Model::Search.index_prefix
+        end
+        
+        should "allow setting and retrieving" do
+          assert_nothing_raised { Model::Search.index_prefix 'app_environment_' }
+          assert_equal 'app_environment_', Model::Search.index_prefix
+        end
+
+        teardown do
+          Model::Search.instance_variable_set(:@index_prefix, nil)
+        end
+        
+      end
+
     end
 
   end


### PR DESCRIPTION
Based on your feedback, reimplemented karmi/tire#97 to use Model::Search setting rather than Tire::Configuration.

This change is a simple solution, similar to couchrest_model's approach, that allows setting a prefix for all automatically generated index names. 

This setting _only_ affects default index names that have not been overridden by a custom index name.

Furthermore, the default behaviour is no prefix, so it will not affect existing codebases.

One potential usage is a per-environment prefix, configured like so:
`Tire::Model::Search.index_prefix "#{Rails.env.to_s.downcase}_"`

This will result in a 'test_articles' index for Article instances when used in tests, and 'development_articles' when used in development.

This change includes:
- Tests
- Tiny amount of code changes 
- Usage info in README.markdown 

Cheers,
Tal
