### PR TITLE
Instrumentation

### DIFF
--- a/lib/tire.rb
+++ b/lib/tire.rb
@@ -40,3 +40,6 @@ module Tire
   end
   module_function :warn
 end
+
+require 'tire/rails/railtie' if defined?(Rails)
+

--- a/lib/tire/rails/controller_runtime.rb
+++ b/lib/tire/rails/controller_runtime.rb
@@ -1,0 +1,34 @@
+require 'active_support/core_ext/module/attr_internal'
+
+module Tire
+  module Rails
+    module ControllerRuntime
+      extend ActiveSupport::Concern
+
+    protected
+
+      attr_internal :tire_runtime
+
+      def cleanup_view_runtime
+        tire_rt_before_render = Tire::Rails::LogSubscriber.reset_runtime
+        runtime = super
+        tire_rt_after_render = Tire::Rails::LogSubscriber.reset_runtime
+        self.tire_runtime = tire_rt_before_render + tire_rt_after_render
+        runtime - tire_rt_after_render
+      end
+
+      def append_info_to_payload(payload)
+        super
+        payload[:tire_runtime] = (tire_runtime || 0) + Tire::Rails::LogSubscriber.reset_runtime
+      end
+
+      module ClassMethods
+        def log_process_action(payload)
+          messages, tire_runtime = super, payload[:tire_runtime]
+          messages << ("Tire: %.1fms" % tire_runtime.to_f) if tire_runtime
+          messages
+        end
+      end
+    end
+  end
+end

--- a/lib/tire/rails/instrumentation.rb
+++ b/lib/tire/rails/instrumentation.rb
@@ -1,0 +1,20 @@
+module Tire
+  module Rails
+    module Instrumentation
+      extend ActiveSupport::Concern
+
+      included do
+        alias_method_chain :perform, :instrumentation
+      end
+
+      module InstanceMethods
+        def perform_with_instrumentation
+          # Wrapper around the Search.perform method that logs search times.
+          ActiveSupport::Notifications.instrument("search.tire", :name => 'Tire search', :search => self.to_json) do
+            perform_without_instrumentation
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/tire/rails/log_subscriber.rb
+++ b/lib/tire/rails/log_subscriber.rb
@@ -1,0 +1,36 @@
+module Tire
+  module Rails
+    class LogSubscriber < ActiveSupport::LogSubscriber
+      def self.runtime=(value)
+        Thread.current["tire_search_runtime"] = value
+      end
+
+      def self.runtime
+        Thread.current["tire_search_runtime"] ||= 0
+      end
+
+      def self.reset_runtime
+        rt, self.runtime = runtime, 0
+        rt
+      end
+
+      def search(event)
+        self.class.runtime += event.duration
+        return unless logger.debug?
+
+        payload = event.payload
+
+        name    = "%s (%.1fms)" % [payload[:name], event.duration]
+        query   = payload[:search].to_s.squeeze ' '
+
+        debug "  #{color(name, BLUE, true)}  #{query}"
+      end
+    end
+  end
+end
+
+# Register with namespace 'tire', so event names look 
+# like '*.tire', e.g. 'search.tire' will invoke the
+# search method in the LogSubscriber above.
+Tire::Rails::LogSubscriber.attach_to :tire
+

--- a/lib/tire/rails/railtie.rb
+++ b/lib/tire/rails/railtie.rb
@@ -1,0 +1,21 @@
+module Tire
+  module Rails
+    class Railtie < ::Rails::Railtie
+      initializer "tire.initializer" do |app|
+        require 'tire/rails/instrumentation'
+        require 'tire/rails/log_subscriber'
+        require 'tire/rails/controller_runtime'
+
+        # Inject instrumentation into Tire::Search
+        Tire::Search::Search.module_eval do
+          include Tire::Rails::Instrumentation
+        end
+
+        # Hook into Rails controllers to provide logging
+        ActiveSupport.on_load(:action_controller) do
+          include Tire::Rails::ControllerRuntime
+        end
+      end
+    end
+  end
+end

--- a/lib/tire/rails/tasks.rb
+++ b/lib/tire/rails/tasks.rb
@@ -1,3 +1,0 @@
-namespace :tire do
-  # TODO add rake tasks: import etc.
-end

--- a/lib/tire/rails/tasks.rb
+++ b/lib/tire/rails/tasks.rb
@@ -1,0 +1,3 @@
+namespace :tire do
+  # TODO add rake tasks: import etc.
+end

--- a/test/integration/log_subscriber_test.rb
+++ b/test/integration/log_subscriber_test.rb
@@ -1,0 +1,78 @@
+require 'test_helper'
+require "active_support/log_subscriber/test_helper"
+require 'tire/rails/log_subscriber'
+require 'tire/rails/instrumentation'
+
+module Tire
+  module Rails
+
+    class LogSubscriberTest < Test::Unit::TestCase
+      include Test::Integration
+      include ActiveSupport::LogSubscriber::TestHelper
+
+      def setup
+        super
+
+        # Make sure instrumentation wraps the perform method
+        Tire::Search::Search.module_eval do
+          include Tire::Rails::Instrumentation
+        end
+        
+        # Attach log subscriber
+        Tire::Rails::LogSubscriber.attach_to :tire
+        
+        ActiveRecord::Base.establish_connection( :adapter => 'sqlite3', :database => ":memory:" )
+
+        ActiveRecord::Migration.verbose = false
+        ActiveRecord::Schema.define(:version => 1) do
+          create_table :active_record_articles do |t|
+            t.string   :title
+            t.datetime :created_at, :default => 'NOW()'
+          end
+          create_table :active_record_comments do |t|
+            t.string     :author
+            t.text       :body
+            t.references :article
+            t.timestamps
+          end
+          create_table :active_record_stats do |t|
+            t.integer    :pageviews
+            t.string     :period
+            t.references :article
+          end
+          create_table :active_record_class_with_tire_methods do |t|
+            t.string     :title
+          end
+        end
+
+        ActiveRecordArticle.destroy_all
+        Tire.index('active_record_articles').delete
+
+        1.upto(9) { |number| ActiveRecordArticle.create :title => "Test#{number}" }
+        ActiveRecordArticle.index.refresh
+
+        load File.expand_path('../../models/active_record_models.rb', __FILE__)
+      end
+
+      def teardown
+        ActiveRecordArticle.destroy_all
+        Tire.index('active_record_articles').delete
+        super
+      end
+
+      context "Rails notifications" do
+
+        should "log event on search" do
+          ActiveRecordArticle.search '*', :load => true
+          wait
+          assert_equal 1, @logger.logged(:debug).size
+          assert_match /Tire/, @logger.logged(:debug).last
+        end
+      
+      end
+
+    end
+
+  end
+end
+


### PR DESCRIPTION
This pull request includes basic support for instrumenting Tire in a Rails app.

It basically adds search runtime to the Rails log, like this:

```
Started GET "/articles?utf8=%E2%9C%93&q=bull*&commit=search" for 127.0.0.1 at 2011-09-15 19:07:00 +0200
  Processing by ArticlesController#index as HTML
  Parameters: {"utf8"=>"✓", "q"=>"bull*", "commit"=>"search"}
  Tire search (6.7ms)  {"query":{"query_string":{"query":"bull*"}}}
  Article Load (0.3ms)  SELECT `articles`.* FROM `articles` WHERE `articles`.`id` IN (104126575, 146022759)
Rendered articles/index.html.erb within layouts/application (13.0ms)
Completed 200 OK in 63ms (Views: 53.7ms | ActiveRecord: 1.8ms | Tire: 6.7ms)
```

Let me know what you think.
