### PR TITLE
Fixing an issue in Rails 3 related to the :load helper and differences between how AR.find() behaves vs. AR.where()

### DIFF
--- a/lib/tire/model/search.rb
+++ b/lib/tire/model/search.rb
@@ -176,7 +176,7 @@ module Tire
         # for the search method.
         #
         def load(options=nil)
-          options ? self.class.find(self.id, options) : self.class.find(self.id)
+          options ? self.class.where(:id => self.id).where(options) : self.class.where(:id => self.id)
         end
 
       end

--- a/lib/tire/results/collection.rb
+++ b/lib/tire/results/collection.rb
@@ -52,7 +52,7 @@ module Tire
             end
 
             ids   = @response['hits']['hits'].map { |h| h['_id'] }
-            records =  @options[:load] === true ? klass.find(ids) : klass.find(ids, @options[:load])
+            records =  @options[:load] === true ? klass.where(:id => ids) : klass.where(:id => ids).where(@options[:load])
 
             # Reorder records to preserve order from search results
             ids.map { |id| records.detect { |record| record.id.to_s == id.to_s } }


### PR DESCRIPTION
Fixing an issue where the find method would break when you pass it an array of ids (that were retrieved from a elasticsearch query) that were a super-set of the ids in the project database.

In other words, Imagine an elastic search index for an entity called a User.

User.search('foo', :load => true).collect(&:id)
["1", "2", "3", "4"]

User.search('foo', :load => true).results
Error -- if your rails database only has ["1", "3"]

---

this is because of a difference in how find() responds to a super-set array compared with the where() ActiveRecord method.
