### PR TITLE
allow removal from index on update_index callback 

### DIFF
--- a/lib/tire/model/search.rb
+++ b/lib/tire/model/search.rb
@@ -126,7 +126,7 @@ module Tire
         #
         def update_index
           instance.send :_run_update_elasticsearch_index_callbacks do
-            if instance.destroyed?
+            if instance.destroyed? || !instance.should_be_indexed?
               index.remove instance
             else
               response  = index.store( instance, {:percolate => percolator} )
@@ -157,6 +157,10 @@ module Tire
             reject { |key, value| ! instance.class.tire.mapping.keys.map(&:to_s).include?(key.to_s) }.
             to_json
           end
+        end
+        
+        def should_be_indexed?
+          true
         end
 
         def matches

--- a/test/integration/active_record_searchable_test.rb
+++ b/test/integration/active_record_searchable_test.rb
@@ -74,6 +74,27 @@ module Tire
         assert_not_nil results.first._score
         assert_equal   'Test', results.first.title
       end
+      
+      should "remove document from index on save if should not be indexed" do
+        a = ActiveRecordArticle.new :title => 'Test'
+        a.save!
+        id = a.id
+
+        a.index.refresh
+
+        results = ActiveRecordArticle.search 'test'
+
+        assert       results.any?
+        assert_equal 1, results.count
+
+        a.update_attribute(:title, "should_not_be_indexed")
+        assert ! a.should_be_indexed?
+
+        a.index.refresh
+
+        results = ActiveRecordArticle.search 'should_not_be_indexed'
+        assert results.empty?
+      end
 
       context "with eager loading" do
         setup do

--- a/test/models/active_record_models.rb
+++ b/test/models/active_record_models.rb
@@ -32,6 +32,10 @@ class ActiveRecordArticle < ActiveRecord::Base
       :stats        => stats.map    { |s| { :pageviews  => s.pageviews } }
     }.to_json
   end
+  
+  def should_be_indexed?
+    title != 'should_not_be_indexed'
+  end
 
   def length
     title.length

--- a/test/unit/model_search_test.rb
+++ b/test/unit/model_search_test.rb
@@ -243,6 +243,16 @@ module Tire
 
           @model.destroy
         end
+        
+        should "remove from index if should not be indexed" do
+          @model = ActiveModelArticleWithCallbacks.new
+          @model.stubs(:id).returns(1)
+
+          @model.expects(:should_be_indexed?).returns(false)
+          Tire::Index.any_instance.expects(:remove)
+          @model.update_index
+        end
+        
 
         should "store the record in index on :update_elasticsearch_index when saved" do
           @model = ActiveModelArticleWithCallbacks.new


### PR DESCRIPTION
I'm working on a project where we have a much larger set of data than I would like to have in the index. For this reason I am using a should_be_indexed? method and if false then submit an empty json in to_indexed_json method.

When an object gets changed and should_be_indexed? conditions change and return false then I want to remove object from the index.
