### PR TITLE
Error fixed when trying to highlight multi_field types.

### DIFF
--- a/lib/tire/results/collection.rb
+++ b/lib/tire/results/collection.rb
@@ -30,7 +30,10 @@ module Tire
 
                  # Update the document with meta information
                  ['_score', '_type', '_index', '_version', 'sort', 'highlight'].each { |key| document.update( {key => h[key]} || {} ) }
-
+                 
+                 highlight = document['highlight']
+                 # Removes unecessary (for highlight) extra names after the field name
+                 document['highlight'] = highlight.map{|name, value| { name.scan(/\w+/).first => value }}.reduce(:merge) if highlight
                  # Return an instance of the "wrapper" class
                  @wrapper.new(document)
                end


### PR DESCRIPTION
When using multi_field types an error ocurred as ActiveRecord tried to set "description.partial" (for example) in the model class. This commit fixes it by using the first word in the field name for highlights. (which means it will still working with non multi_field types)
