### PR TITLE
Fix rake task: apply settings on index creation and fix progress bar

### DIFF
--- a/lib/tire/tasks.rb
+++ b/lib/tire/tasks.rb
@@ -55,7 +55,7 @@ namespace :tire do
       mapping = defined?(Yajl) ? Yajl::Encoder.encode(klass.tire.mapping_to_hash, :pretty => true) :
                                  MultiJson.encode(klass.tire.mapping_to_hash)
       puts "[IMPORT] Creating index '#{index.name}' with mapping:", mapping
-      index.create :mappings => klass.tire.mapping_to_hash
+      index.create :mappings => klass.tire.mapping_to_hash, :settings => klass.tire.settings
     end
 
     STDOUT.sync = true

--- a/lib/tire/tasks.rb
+++ b/lib/tire/tasks.rb
@@ -70,7 +70,7 @@ namespace :tire do
       index.import(klass, 'paginate', params) do |documents|
 
         if total
-          done += documents.size
+          done += defined?(Mongoid::Criteria) && documents.is_a?(Mongoid::Criteria) ? documents.count(true) : documents.size
           # I CAN HAZ PROGREZ BAR LIEK HOMEBRU!
           percent  = ( (done.to_f / total) * 100 ).to_i
           glyphs   = ( percent * ( (tty_cols-offset).to_f/100 ) ).to_i


### PR DESCRIPTION
1. Settings are not applied if index is created from rake task. Added settings to index creation in rake task.
2. When using rake task with mongoid, progress bar goes over 100%. This is because mongodb ignores limit and skip parameters for a count query. Additional parameter must be passed to take limit into account. Ref: http://www.mongodb.org/display/DOCS/Advanced+Queries#AdvancedQueries-%7B%7Bcount%28%29%7D%7D
