### PR TITLE
allow multiple calls to filter, and the filters defined by calls

### DIFF
--- a/lib/tire/search.rb
+++ b/lib/tire/search.rb
@@ -89,7 +89,13 @@ module Tire
         request.update( { :query  => @query.to_hash } )    if @query
         request.update( { :sort   => @sort.to_ary   } )    if @sort
         request.update( { :facets => @facets.to_hash } )   if @facets
-        @filters.each { |filter| request.update( { :filter => filter.to_hash } ) } if @filters
+        if @filters
+          filters = []
+          @filters.each do |filter|
+            filters << filter.to_hash
+          end
+          request.update( {:filter => { :and => filters } } )
+        end
         request.update( { :highlight => @highlight.to_hash } ) if @highlight
         request.update( { :size => @size } )               if @size
         request.update( { :from => @from } )               if @from

--- a/lib/tire/search.rb
+++ b/lib/tire/search.rb
@@ -89,13 +89,7 @@ module Tire
         request.update( { :query  => @query.to_hash } )    if @query
         request.update( { :sort   => @sort.to_ary   } )    if @sort
         request.update( { :facets => @facets.to_hash } )   if @facets
-        if @filters
-          filters = []
-          @filters.each do |filter|
-            filters << filter.to_hash
-          end
-          request.update( {:filter => { :and => filters } } )
-        end
+        request.update( { :filter => { :and => @filters.inject([]) { |filters, filter| filters << filter.to_hash } } } ) if @filters
         request.update( { :highlight => @highlight.to_hash } ) if @highlight
         request.update( { :size => @size } )               if @size
         request.update( { :from => @from } )               if @from

--- a/lib/tire/tasks.rb
+++ b/lib/tire/tasks.rb
@@ -55,7 +55,7 @@ namespace :tire do
       mapping = defined?(Yajl) ? Yajl::Encoder.encode(klass.tire.mapping_to_hash, :pretty => true) :
                                  MultiJson.encode(klass.tire.mapping_to_hash)
       puts "[IMPORT] Creating index '#{index.name}' with mapping:", mapping
-      index.create :mappings => klass.tire.mapping_to_hash
+      index.create :mappings => klass.tire.mapping_to_hash, :settings => klass.tire.settings
     end
 
     STDOUT.sync = true

--- a/lib/tire/tasks.rb
+++ b/lib/tire/tasks.rb
@@ -70,7 +70,7 @@ namespace :tire do
       index.import(klass, 'paginate', params) do |documents|
 
         if total
-          done += documents.size
+          done += defined?(Mongoid::Criteria) && documents.is_a?(Mongoid::Criteria) ? documents.count(true) : documents.size
           # I CAN HAZ PROGREZ BAR LIEK HOMEBRU!
           percent  = ( (done.to_f / total) * 100 ).to_i
           glyphs   = ( percent * ( (tty_cols-offset).to_f/100 ) ).to_i

--- a/test/integration/filters_test.rb
+++ b/test/integration/filters_test.rb
@@ -39,6 +39,16 @@ module Tire
         assert_equal 3, s.results.facets['tags']['terms'].size
       end
 
+      should "filter the results with multiple calls to filters" do
+        s = Tire.search('articles-test') do
+          filter :term,  :words => 125
+          filter :terms, :tags => ["java"]
+        end
+
+        assert_equal 1, s.results.count
+        assert_equal 'Five', s.results.first.title
+      end
+
     end
 
   end


### PR DESCRIPTION
It seems there can be only one call to `filter` in a search block. If there are more, only latest filter will be used. It was not intuitive to me. I think if there are more than one calls to filter all the filters should be joined with **and**. Had done some changes to do the same.

Let me know if it is not what you want or if there can be a better way to do it.
