### PR TITLE
Allow multiple filter calls to be joined with 'and'

### DIFF
--- a/lib/tire/search.rb
+++ b/lib/tire/search.rb
@@ -89,7 +89,8 @@ module Tire
         request.update( { :query  => @query.to_hash } )    if @query
         request.update( { :sort   => @sort.to_ary   } )    if @sort
         request.update( { :facets => @facets.to_hash } )   if @facets
-        @filters.each { |filter| request.update( { :filter => filter.to_hash } ) } if @filters
+        request.update( { :filter => @filters.first.to_hash } ) if @filters && @filters.size == 1
+        request.update( { :filter => { :and => @filters.inject([]) { |filters, filter| filters << filter.to_hash } } } ) if  @filters && @filters.size > 1
         request.update( { :highlight => @highlight.to_hash } ) if @highlight
         request.update( { :size => @size } )               if @size
         request.update( { :from => @from } )               if @from

--- a/test/integration/filters_test.rb
+++ b/test/integration/filters_test.rb
@@ -39,6 +39,16 @@ module Tire
         assert_equal 3, s.results.facets['tags']['terms'].size
       end
 
+      should "filter the results with multiple calls to filters" do
+        s = Tire.search('articles-test') do
+          filter :term,  :words => 125
+          filter :terms, :tags => ["java"]
+        end
+
+        assert_equal 1, s.results.count
+        assert_equal 'Five', s.results.first.title
+      end
+
     end
 
   end

--- a/test/unit/search_test.rb
+++ b/test/unit/search_test.rb
@@ -185,6 +185,34 @@ module Tire
           assert_not_nil s.filters.first[:terms]
         end
 
+        should "allow adding multiple filters" do
+          s = Search::Search.new('index') do
+            filter :terms, :tags => ['foo']
+            filter :term,  :words => 125
+          end
+
+          assert_equal 2, s.filters.size
+          assert_not_nil  s.filters.first["terms"]
+          assert_not_nil  s.filters.last["term"]
+        end
+
+        should "join multiple filters with 'and'" do
+          s = Search::Search.new('index') do
+            filter :terms, :tags => ['foo']
+            filter :term,  :words => 125
+          end
+
+          assert_equal({ :and => [ {:terms => {:tags => ['foo']}}, {:term => {:words => 125}} ] },
+                       s.to_hash[:filter].to_json)
+        end
+
+        should "not add 'and' to single filter" do
+          s = Search::Search.new('index') do
+            filter :terms, :tags => ['foo']
+          end
+
+          assert_equal({:terms => {:tags => ['foo']}}.to_json, s.to_hash[:filter].to_json)
+        end
       end
 
       context "highlight" do

--- a/test/unit/search_test.rb
+++ b/test/unit/search_test.rb
@@ -192,8 +192,8 @@ module Tire
           end
 
           assert_equal 2, s.filters.size
-          assert_not_nil  s.filters.first["terms"]
-          assert_not_nil  s.filters.last["term"]
+          assert_not_nil  s.filters.first[:terms]
+          assert_not_nil  s.filters.last[:term]
         end
 
         should "join multiple filters with 'and'" do

--- a/test/unit/search_test.rb
+++ b/test/unit/search_test.rb
@@ -197,12 +197,12 @@ module Tire
         end
 
         should "join multiple filters with 'and'" do
-          s = Search::Search.new('index') do
+          s = ::Tire::Search::Search.new('index') do
             filter :terms, :tags => ['foo']
             filter :term,  :words => 125
           end
 
-          assert_equal({ :and => [ {:terms => {:tags => ['foo']}}, {:term => {:words => 125}} ] },
+          assert_equal({ :and => [ {:terms => {:tags => ['foo']}}, {:term => {:words => 125}} ] }.to_json,
                        s.to_hash[:filter].to_json)
         end
 


### PR DESCRIPTION
Added test cases to demonstrate partial support for multiple filters, but being ignored while generating search json. Added support to join multiple filters with `and`.

I guess eventually filters should have something like `Query#boolean`. 
