### PR TITLE
Allow to create mapping for type nested

### DIFF
--- a/lib/tire/model/indexing.rb
+++ b/lib/tire/model/indexing.rb
@@ -68,15 +68,14 @@ module Tire
         # for more information.
         #
         def indexes(name, options = {}, &block)
-          options[:type] ||= 'string'
-
           if block_given?
-            mapping[name] ||= { :type => 'object', :properties => {} }
+            mapping[name] ||= { :type => 'object', :properties => {} }.update(options)
             @_nested_mapping = name
             nested = yield
             @_nested_mapping = nil
             self
           else
+            options[:type] ||= 'string'
             if @_nested_mapping
               mapping[@_nested_mapping][:properties][name] = options
             else

--- a/test/integration/active_model_searchable_test.rb
+++ b/test/integration/active_model_searchable_test.rb
@@ -38,6 +38,15 @@ module Tire
         assert_equal 'string', ActiveRecordArticle.index.mapping['active_record_article']['properties']['author']['properties']['name']['type']
       end
 
+      should "use options passed to nested indexes if given" do
+        assert_equal 'nested', ActiveRecordArticle.mapping[:comments][:type]
+        assert_equal true, ActiveRecordArticle.mapping[:comments][:include_in_parent]
+        assert_equal [:author_name, :body], ActiveRecordArticle.mapping[:comments][:properties].keys
+
+        assert_equal 'nested', ActiveRecordArticle.index.mapping['active_record_article']['properties']['comments']['type']
+        assert_equal ['author_name', 'body'].sort, ActiveRecordArticle.index.mapping['active_record_article']['properties']['comments']['properties'].keys.sort
+      end
+
       should "save document into index on save and find it with score" do
         a = SupermodelArticle.new :title => 'Test'
         a.save

--- a/test/integration/active_model_searchable_test.rb
+++ b/test/integration/active_model_searchable_test.rb
@@ -31,6 +31,13 @@ module Tire
         assert_equal 'czech', SupermodelArticle.index.mapping['supermodel_article']['properties']['title']['analyzer']
       end
 
+      should "configure defaults for mappings" do
+        assert_equal 'object', ActiveRecordArticle.mapping[:author][:type]
+        assert_equal 'string', ActiveRecordArticle.mapping[:author][:properties][:name][:type]
+
+        assert_equal 'string', ActiveRecordArticle.index.mapping['active_record_article']['properties']['author']['properties']['name']['type']
+      end
+
       should "save document into index on save and find it with score" do
         a = SupermodelArticle.new :title => 'Test'
         a.save

--- a/test/integration/active_record_searchable_test.rb
+++ b/test/integration/active_record_searchable_test.rb
@@ -55,6 +55,13 @@ module Tire
         assert_equal 'snowball', ActiveRecordArticle.index.mapping['active_record_article']['properties']['title']['analyzer']
       end
 
+      should "configure defaults for mappings" do
+        assert_equal 'object', ActiveRecordArticle.mapping[:author][:type]
+        assert_equal 'string', ActiveRecordArticle.mapping[:author][:properties][:name][:type]
+
+        assert_equal 'string', ActiveRecordArticle.index.mapping['active_record_article']['properties']['author']['properties']['name']['type']
+      end
+
       should "save document into index on save and find it" do
         a = ActiveRecordArticle.new :title => 'Test'
         a.save!

--- a/test/integration/active_record_searchable_test.rb
+++ b/test/integration/active_record_searchable_test.rb
@@ -62,6 +62,16 @@ module Tire
         assert_equal 'string', ActiveRecordArticle.index.mapping['active_record_article']['properties']['author']['properties']['name']['type']
       end
 
+      should "use options passed to nested indexes if given" do
+        assert_equal 'nested', ActiveRecordArticle.mapping[:comments][:type]
+        assert_equal true, ActiveRecordArticle.mapping[:comments][:include_in_parent]
+        assert_equal [:author_name, :body], ActiveRecordArticle.mapping[:comments][:properties].keys
+
+        assert_equal 'nested', ActiveRecordArticle.index.mapping['active_record_article']['properties']['comments']['type']
+        assert_equal ['author_name', 'body'].sort, ActiveRecordArticle.index.mapping['active_record_article']['properties']['comments']['properties'].keys.sort
+      end
+
+
       should "save document into index on save and find it" do
         a = ActiveRecordArticle.new :title => 'Test'
         a.save!

--- a/test/integration/mongoid_searchable_test.rb
+++ b/test/integration/mongoid_searchable_test.rb
@@ -49,6 +49,15 @@ if ENV["MONGODB_IS_AVAILABLE"]
           assert_equal 'string', ActiveRecordArticle.index.mapping['active_record_article']['properties']['author']['properties']['name']['type']
         end
 
+        should "use options passed to nested indexes if given" do
+          assert_equal 'nested', ActiveRecordArticle.mapping[:comments][:type]
+          assert_equal true, ActiveRecordArticle.mapping[:comments][:include_in_parent]
+          assert_equal [:author_name, :body], ActiveRecordArticle.mapping[:comments][:properties].keys
+
+          assert_equal 'nested', ActiveRecordArticle.index.mapping['active_record_article']['properties']['comments']['type']
+          assert_equal ['author_name', 'body'].sort, ActiveRecordArticle.index.mapping['active_record_article']['properties']['comments']['properties'].keys.sort
+        end
+
         should "save document into index on save and find it" do
           a = MongoidArticle.new :title => 'Test'
           a.save!

--- a/test/integration/mongoid_searchable_test.rb
+++ b/test/integration/mongoid_searchable_test.rb
@@ -42,6 +42,13 @@ if ENV["MONGODB_IS_AVAILABLE"]
           assert_equal 'snowball', MongoidArticle.tire.index.mapping['mongoid_article']['properties']['title']['analyzer']
         end
 
+        should "configure defaults for mappings" do
+          assert_equal 'object', ActiveRecordArticle.mapping[:author][:type]
+          assert_equal 'string', ActiveRecordArticle.mapping[:author][:properties][:name][:type]
+
+          assert_equal 'string', ActiveRecordArticle.index.mapping['active_record_article']['properties']['author']['properties']['name']['type']
+        end
+
         should "save document into index on save and find it" do
           a = MongoidArticle.new :title => 'Test'
           a.save!

--- a/test/models/active_record_models.rb
+++ b/test/models/active_record_models.rb
@@ -13,8 +13,12 @@ class ActiveRecordArticle < ActiveRecord::Base
       indexes :title,      :type => 'string', :boost => 10, :analyzer => 'snowball'
       indexes :created_at, :type => 'date'
 
-      indexes :comments do
-        indexes :author
+      indexes :author do
+        indexes :name
+      end
+
+      indexes :comments, :type => 'nested', :include_in_parent => true do
+        indexes :author_name
         indexes :body
       end
     end

--- a/test/models/mongoid_models.rb
+++ b/test/models/mongoid_models.rb
@@ -25,8 +25,12 @@ class MongoidArticle
       indexes :title,      :type => 'string', :boost => 10, :analyzer => 'snowball'
       indexes :created_at, :type => 'date'
 
-      indexes :comments do
-        indexes :author
+      indexes :author do
+        indexes :name
+      end
+
+      indexes :comments, :type => 'nested', :include_in_parent => true do
+        indexes :author_name
         indexes :body
       end
     end

--- a/test/models/supermodel_article.rb
+++ b/test/models/supermodel_article.rb
@@ -11,6 +11,15 @@ class SupermodelArticle < SuperModel::Base
 
   mapping do
     indexes :title,      :type => 'string', :boost => 15, :analyzer => 'czech'
+
+    indexes :author do
+      indexes :name
+    end
+
+    indexes :comments, :type => 'nested', :include_in_parent => true do
+      indexes :author_name
+      indexes :body
+    end
   end
 
   alias :persisted? :exists?


### PR DESCRIPTION
There is currently no way to define [nested type](http://www.elasticsearch.org/guide/reference/mapping/nested-type.html) in mapping.. This pull request adds support for defining nested mapping type by passing options and adds tests around it.
