### PR TITLE
add support for analyze api

### DIFF
--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -181,6 +181,19 @@ module Tire
       logged(error, '_close', curl)
     end
 
+    def analyze(text, options={})
+      options = {:pretty => true}.update(options)
+      query = options.inject("") { |query, arr| query << arr[0].to_s << "=" << arr[1].to_s << "&" }
+      query = query.slice(0, query.size - 1)
+      @response = Configuration.client.get "#{Configuration.url}/#{@name}/_analyze?#{query}", text
+      @response.success? ? MultiJson.decode(@response.body) : false
+    rescue Exception => error
+      raise
+    ensure
+      curl = %Q|curl -X GET "#{Configuration.url}/#{@name}/_analyze?#{query}" -d '#{text}'|
+      logged(error, '_analyze', curl)
+    end
+
     def register_percolator_query(name, options={}, &block)
       options[:query] = Search::Query.new(&block).to_hash if block_given?
 

--- a/test/unit/index_test.rb
+++ b/test/unit/index_test.rb
@@ -59,6 +59,13 @@ module Tire
         assert_nothing_raised { assert @index.close }
       end
 
+      should "analyze text" do
+        Configuration.client.expects(:get).returns(mock_response(
+            '{"tokens":[{"token":"tire","start_offset":0,"end_offset":4,"type":"<ALPHANUM>","position":1}]}'
+        ))
+        assert_nothing_raised { assert @index.analyze("tire") }
+      end
+
       context "mapping" do
 
         should "create index with mapping" do

--- a/test/unit/index_test.rb
+++ b/test/unit/index_test.rb
@@ -60,10 +60,12 @@ module Tire
       end
 
       should "analyze text" do
-        Configuration.client.expects(:get).returns(mock_response(
+        Configuration.client.expects(:get).times(3).returns(mock_response(
             '{"tokens":[{"token":"tire","start_offset":0,"end_offset":4,"type":"<ALPHANUM>","position":1}]}'
         ))
         assert_nothing_raised { assert @index.analyze("tire") }
+        assert_nothing_raised { assert @index.analyze("tire", :analyzer => 'whitespace') }
+        assert_nothing_raised { assert @index.analyze("tire", :field => 'title') }
       end
 
       context "mapping" do


### PR DESCRIPTION
Adds support for [analyze api](http://www.elasticsearch.org/guide/reference/api/admin-indices-analyze.html). Very helpful when debugging why search is not working as expected, what terms a particular analyzer will generate or what terms ES is generating for the field.

Usage:

``` ruby
index.analyze("karmi/tire")
index.analyze("karmi/tire", :analyzer => 'whitespace')
index.analyze("karmi/tire", :field => 'title')
```
