### PR TITLE
Dynamic temples in a model, bulk load sleep on retries, and 

### DIFF
--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -87,7 +87,13 @@ module Tire
       rescue Exception => error
         if count < tries
           count += 1
-          STDERR.puts "[ERROR] #{error.message}, retrying (#{count})..."
+          if ENV['BULK_RETRY_SLEEP_SECS']
+            sleep_time = count * ENV['BULK_RETRY_SLEEP_SECS'].to_i
+            STDERR.puts "[ERROR] #{error.message}, sleeping for #{sleep_time}sec & retrying (#{count})..."
+            sleep(sleep_time)
+          else
+            STDERR.puts "[ERROR] #{error.message}, retrying (#{count})..."
+          end
           retry
         else
           STDERR.puts "[ERROR] Too many exceptions occured, giving up. The HTTP response was: #{error.message}"

--- a/lib/tire/model/indexing.rb
+++ b/lib/tire/model/indexing.rb
@@ -86,6 +86,66 @@ module Tire
           end
         end
 
+        # Define the [_dynamic_templates_](http://www.elasticsearch.org/guide/reference/mapping/root-object-type.html)
+        # for the corresponding index, telling _ElasticSearch_ how to understand your documents:
+        # how to process dynamic mappings, whether it is analyzed or no, which analyzer to use, etc.
+        #
+        # Usage:
+        #
+        #     class Article
+        #       # ...
+        #       mapping do
+        #         dynamic_template do
+        #           templates :string, :match => "*", :match_mapping_type => "string", :mapping => {:type => "string", :store => 'no', :index => 'analyzed', :include_in_all => true}
+        #            templates :long, :match => "*", :match_mapping_type => "long", :mapping => {:type => "long", :store => 'no', :include_in_all => false}
+        #            # ....
+        #         end
+        #
+        #         indexes :id,    :type => 'string',  :index    => :not_analyzed
+        #         indexes :title, :type => 'string',  :analyzer => 'snowball',   :boost => 100
+        #         # ...
+        #       end
+        #     end
+        #
+        def dynamic_template
+          @dynamic_template ||= {}
+          if block_given?
+            yield
+          else
+            @dynamic_template
+          end
+        end
+
+        # Define dynamic template for the property passed as the first argument (`name`)
+        # using definition from the second argument (`options`).
+        #
+        # Usage:
+        #
+        # * Index all strings and analyze them: `indexes :string, :match => "*", :match_mapping_type => "string", :mapping => {:type => "string", :index => :analyzed}`
+        #
+        # * Use different analyzer for indexing a property: `indexes :title, :analyzer => 'snowball'`
+        #
+        # Please refer to the
+        # [_object_type_ documentation](http://www.elasticsearch.org/guide/reference/mapping/object-type.html)
+        # for more information.
+        #
+        def templates(name, options = {}, &block)
+          if block_given?
+            dynamic_template[name] ||= { :type => 'object', :properties => {} }
+            @_nested_template = name
+            nested = yield
+            @_nested_template = nil
+            self
+          else
+            if @_nested_template
+              dynamic_template[@_nested_template][:properties][name] = options
+            else
+              dynamic_template[name] = options
+            end
+            self
+          end
+        end
+
         # Creates the corresponding index with desired settings and mappings, when it does not exists yet.
         #
         def create_elasticsearch_index
@@ -102,7 +162,11 @@ module Tire
         end
 
         def mapping_to_hash
-          { document_type.to_sym => { :properties => mapping } }
+          mh = { :properties => mapping }
+          unless dynamic_template.empty?
+            mh[:dynamic_templates] = dynamic_template.map { |k, v| {k => v} }
+          end
+          { document_type.to_sym => mh }
         end
 
       end

--- a/lib/tire/model/search.rb
+++ b/lib/tire/model/search.rb
@@ -90,6 +90,7 @@ module Tire
           else
             s.query { string query }
           end
+          s.fields [options[:fields]] if options[:fields]
 
           s.perform.results
         end

--- a/test/unit/index_test.rb
+++ b/test/unit/index_test.rb
@@ -95,6 +95,29 @@ module Tire
           assert_equal 2.0,      @index.mapping['article']['properties']['title']['boost']
         end
 
+
+        should "create index with dynamic templates" do
+          Configuration.client.expects(:post).returns(mock_response('{"ok":true,"acknowledged":true}'))
+
+          assert @index.create :settings => { :number_of_shards => 1 },
+            :mappings => {
+              :article => {
+                :dynamic_templates => [ {:string => { :match_mapping_type => 'string',
+                                          :match =>'*',
+                                          :mapping => {
+                                             :index => 'analyzed',
+                                              :type => 'string',
+                                              :include_in_all => false, :store=>'no' }
+                                          } } ],
+                :properties => {
+                  :title => { :boost => 2.0,
+                    :type => 'string',
+                    :store => 'yes',
+                    :analyzer => 'snowball' }
+                }
+              }
+            }
+        end
       end
 
       context "when storing" do

--- a/test/unit/model_search_test.rb
+++ b/test/unit/model_search_test.rb
@@ -213,6 +213,12 @@ module Tire
             ActiveModelArticle.search @q, :per_page => 10, :page => 3
           end
 
+          should "allow to specify fields option" do
+            Tire::Search::Search.any_instance.expects(:fields).with(["id"])
+
+            ActiveModelArticle.search @q, :fields => "id"
+          end
+
         end
 
         should "not set callback when hooks are missing" do


### PR DESCRIPTION
This adds the ability to define dynamic temples in a model's mapping, configure a sleep time between retries for bulk load, and allows setting fields in query string search.

Thanks,
Dave
