### PR TITLE
Added support for mapping fields

### DIFF
--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -91,6 +91,7 @@ module Tire
           retry
         else
           STDERR.puts "[ERROR] Too many exceptions occured, giving up. The HTTP response was: #{error.message}"
+          raise
         end
       ensure
         curl = %Q|curl -X POST "#{Configuration.url}/_bulk" -d '{... data omitted ...}'|

--- a/lib/tire/model/indexing.rb
+++ b/lib/tire/model/indexing.rb
@@ -35,7 +35,7 @@ module Tire
         #
         #     class Article
         #       # ...
-        #       mapping do
+        #       mapping :_source => { :compress => true } do
         #         indexes :id,    :type => 'string',  :index    => :not_analyzed
         #         indexes :title, :type => 'string',  :analyzer => 'snowball',   :boost => 100
         #         # ...

--- a/lib/tire/model/indexing.rb
+++ b/lib/tire/model/indexing.rb
@@ -42,9 +42,10 @@ module Tire
         #       end
         #     end
         #
-        def mapping
+        def mapping(*args)
           @mapping ||= {}
           if block_given?
+            @fields = args.pop
             @store_mapping = true and yield and @store_mapping = false
             create_elasticsearch_index
           else
@@ -100,8 +101,12 @@ module Tire
           @store_mapping || false
         end
 
+        def fields
+          @fields || {}
+        end
+
         def mapping_to_hash
-          { document_type.to_sym => { :properties => mapping } }
+          { document_type.to_sym => fields.merge({ :properties => mapping }) }
         end
 
       end

--- a/test/unit/model_search_test.rb
+++ b/test/unit/model_search_test.rb
@@ -273,6 +273,7 @@ module Tire
             expected = {
               :settings => {},
               :mappings => { :model_with_custom_mapping => {
+                :_source => { :compress => true },
                 :properties => { :title => { :type => 'string', :analyzer => 'snowball', :boost => 10 } }
               }}
             }
@@ -286,7 +287,7 @@ module Tire
               include Tire::Model::Search
               include Tire::Model::Callbacks
 
-              mapping do
+              mapping :_source => { :compress => true } do
                 indexes :title, :type => 'string', :analyzer => 'snowball', :boost => 10
               end
 


### PR DESCRIPTION
I added support for the multiple fields (_source, _all, etc) that are supported by the elasticsearch mapping when the index is defined using the ActiveModel integration.
