### PR TITLE
Add support for multitype search and eager loading

### DIFF
--- a/lib/tire/results/collection.rb
+++ b/lib/tire/results/collection.rb
@@ -54,7 +54,13 @@ module Tire
             end
 
             ids   = @response['hits']['hits'].map { |h| h['_id'] }
-            records =  @options[:load] === true ? klass.find(ids) : klass.find(ids, @options[:load])
+
+            load_options = options[:load] === true ? {} : options[:load]
+            # Tolerate missing records by not giving find the array of ids
+            records = klass.where(klass.primary_key.to_sym => ids).find(:all, load_options)
+
+            # Remove missing records from the total
+            @total -= ids.size - records.size
 
             # Reorder records to preserve order from search results
             ids.map { |id| records.detect { |record| record.id.to_s == id.to_s } }

--- a/lib/tire/search.rb
+++ b/lib/tire/search.rb
@@ -9,9 +9,9 @@ module Tire
       def initialize(indices=nil, options = {}, &block)
         @indices = Array(indices)
         @options = options
-        @type    = @options[:type]
+        @type    = Array(@options[:type])
 
-        @url     = Configuration.url+['/', @indices.join(','), @type, '_search'].compact.join('/').squeeze('/')
+        @url     = Configuration.url+['/', @indices.join(','), @type.join(','), '_search'].compact.join('/').squeeze('/')
 
         block.arity < 1 ? instance_eval(&block) : block.call(self) if block_given?
       end

--- a/test/unit/results_collection_test.rb
+++ b/test/unit/results_collection_test.rb
@@ -218,9 +218,9 @@ module Tire
 
         should "load the records via model find method from database" do
           mock_relation = Object.new
-          ActiveRecordArticle.expects(:where).with(:id => [1, 2, 3]).
+          ActiveRecordArticle.expects(:where).with('id' => [1, 2, 3]).
                               returns(mock_relation)
-          mock_relation.expects(:find).with(:all, {}).
+          mock_relation.expects(:all).with({}).
                               returns([ Results::Item.new(:id => 3),
                                         Results::Item.new(:id => 1),
                                         Results::Item.new(:id => 2)  ])
@@ -229,9 +229,9 @@ module Tire
 
         should "pass the :load option Hash to model find metod" do
           mock_relation = Object.new
-          ActiveRecordArticle.expects(:where).with(:id => [1, 2, 3]).
+          ActiveRecordArticle.expects(:where).with('id' => [1, 2, 3]).
                               returns(mock_relation)
-          mock_relation.expects(:find).with(:all, { :include => 'comments' }).
+          mock_relation.expects(:all).with({ :include => 'comments' }).
                               returns([ Results::Item.new(:id => 3),
                                         Results::Item.new(:id => 1),
                                         Results::Item.new(:id => 2)  ])
@@ -240,9 +240,9 @@ module Tire
 
         should "preserve the order of records returned from search" do
           mock_relation = Object.new
-          ActiveRecordArticle.expects(:where).with(:id => [1, 2, 3]).
+          ActiveRecordArticle.expects(:where).with('id' => [1, 2, 3]).
                               returns(mock_relation)
-          mock_relation.expects(:find).with(:all, {}).
+          mock_relation.expects(:all).with({}).
                               returns([ Results::Item.new(:id => 3),
                                         Results::Item.new(:id => 1),
                                         Results::Item.new(:id => 2)  ])

--- a/test/unit/results_collection_test.rb
+++ b/test/unit/results_collection_test.rb
@@ -217,7 +217,10 @@ module Tire
         end
 
         should "load the records via model find method from database" do
-          ActiveRecordArticle.expects(:find).with([1,2,3]).
+          mock_relation = Object.new
+          ActiveRecordArticle.expects(:where).with(:id => [1, 2, 3]).
+                              returns(mock_relation)
+          mock_relation.expects(:find).with(:all, {}).
                               returns([ Results::Item.new(:id => 3),
                                         Results::Item.new(:id => 1),
                                         Results::Item.new(:id => 2)  ])
@@ -225,7 +228,10 @@ module Tire
         end
 
         should "pass the :load option Hash to model find metod" do
-          ActiveRecordArticle.expects(:find).with([1,2,3], :include => 'comments').
+          mock_relation = Object.new
+          ActiveRecordArticle.expects(:where).with(:id => [1, 2, 3]).
+                              returns(mock_relation)
+          mock_relation.expects(:find).with(:all, { :include => 'comments' }).
                               returns([ Results::Item.new(:id => 3),
                                         Results::Item.new(:id => 1),
                                         Results::Item.new(:id => 2)  ])
@@ -233,7 +239,10 @@ module Tire
         end
 
         should "preserve the order of records returned from search" do
-          ActiveRecordArticle.expects(:find).with([1,2,3]).
+          mock_relation = Object.new
+          ActiveRecordArticle.expects(:where).with(:id => [1, 2, 3]).
+                              returns(mock_relation)
+          mock_relation.expects(:find).with(:all, {}).
                               returns([ Results::Item.new(:id => 3),
                                         Results::Item.new(:id => 1),
                                         Results::Item.new(:id => 2)  ])


### PR DESCRIPTION
Although searching across multiple types could be previously done with using a comma separated string for the type, the eager loading would still assume only one type was searched for.  This patch fixes this by grouping the results by type, then performing one query per type to eager load the actual records.
