### PR TITLE
on debug level, the logger will fail when performing a search fails

### DIFF
--- a/lib/tire/logger.rb
+++ b/lib/tire/logger.rb
@@ -47,7 +47,7 @@ module Tire
       content += " [#{status}]"
       content += " (#{took} msec)" if took
       content += "\n#\n" unless json == ''
-      json.each_line { |line| content += "# #{line}" } unless json == ''
+      json.each_line { |line| content += "# #{line}" } unless (json == '' || json.nil?)
       content += "\n\n"
       write content
     end


### PR DESCRIPTION
e.g. if the elastic search server is not running (or other causes if SearchRequestFailed in Tire::Search::Search#perform) the logger try to print the a null body and results in:

activesupport (3.1.0) lib/active_support/whiny_nil.rb:48:in `method_missing'
tire (0.3.8) lib/tire/logger.rb:50:in`log_response'
tire (0.3.8) lib/tire/search.rb:124:in `logged'
tire (0.3.8) lib/tire/search.rb:80:in`perform'
tire (0.3.8) lib/tire/model/search.rb:97:in `search'
tire (0.3.8) lib/tire/model/search.rb:264:in`**send**'
tire (0.3.8) lib/tire/model/search.rb:264:in `search'
