### PR TITLE
Add support for text queries to the DSL

### DIFF
--- a/lib/tire/search/query.rb
+++ b/lib/tire/search/query.rb
@@ -20,6 +20,12 @@ module Tire
       def range(field, value)
         @value = { :range => { field => value } }
       end
+      
+      def text(field, value, options={})
+        query_options = { :query => value }.update(options)
+        @value = { :text => { field => query_options } }
+        @value
+      end
 
       def string(value, options={})
         @value = { :query_string => { :query => value } }

--- a/test/integration/query_string_test.rb
+++ b/test/integration/query_string_test.rb
@@ -12,6 +12,12 @@ module Tire
         assert_equal 1, search(q).results.count
         assert_equal 'One', search(q).results.first[:title]
       end
+      
+      should "find article by free text" do
+        q = 'one' 
+        assert_equal 1, text('title', q).results.count
+        assert_equal 'One', text('title', q).results.first[:title]
+      end
 
       should "find articles by title with boosting" do
         q = 'title:one^100 OR title:two'
@@ -45,6 +51,10 @@ module Tire
 
     def search(q)
       Tire.search('articles-test') { query { string q } }
+    end
+    
+    def text(field, q)
+      Tire.search('articles-test') { query { text(field, q) } }
     end
 
   end

--- a/test/unit/search_query_test.rb
+++ b/test/unit/search_query_test.rb
@@ -37,6 +37,10 @@ module Tire::Search
       should "allow search for a range" do
         assert_equal( { :range => { :age => { :gte => 21 } } }, Query.new.range(:age, { :gte => 21 }) )
       end
+      
+      should "allow use of the text search" do
+        assert_equal( { :text => {'field' => {:query => 'foo'}}}, Query.new.text('field', 'foo'))
+      end
 
       should "allow search with a query string" do
         assert_equal( { :query_string => { :query => 'title:foo' } },


### PR DESCRIPTION
There is a quick unit test for this as well, but I was unable to execute it because I had trouble getting the test suite working. 

Small addition to support: 
http://www.elasticsearch.org/guide/reference/query-dsl/text-query.html

Thanks, 

Nathan
