### PR TITLE
Support setting multiple URLS in the configuration

### DIFF
--- a/lib/tire/configuration.rb
+++ b/lib/tire/configuration.rb
@@ -7,6 +7,7 @@ module Tire
     end
 
     def self.url(*values)
+      values.flatten!
       @urls = values.map{|value| value.to_s.gsub(%r|/*$|, '')} if values.any?
       urls.respond_to?(:sample) ? urls.sample : urls.choice
     end

--- a/lib/tire/configuration.rb
+++ b/lib/tire/configuration.rb
@@ -2,13 +2,13 @@ module Tire
 
   class Configuration
 
-    def self.urls(values=nil)
-      @urls = (values && values.any? ? values.map{|value| value.to_s.gsub(%r|/*$|, '')} : nil) || @urls || ["http://localhost:9200"]
+    def self.urls
+      @urls || ["http://localhost:9200"]
     end
 
-    def self.url(value=nil)
-      urls([value])
-      @urls.respond_to?(:sample) ? @urls.sample : @urls.choice
+    def self.url(*values)
+      @urls = values.map{|value| value.to_s.gsub(%r|/*$|, '')} if values.any?
+      urls.respond_to?(:sample) ? urls.sample : urls.choice
     end
 
     def self.client(klass=nil)

--- a/lib/tire/configuration.rb
+++ b/lib/tire/configuration.rb
@@ -2,8 +2,13 @@ module Tire
 
   class Configuration
 
+    def self.urls(values=nil)
+      @urls = (values && values.any? ? values.map{|value| value.to_s.gsub(%r|/*$|, '')} : nil) || @urls || ["http://localhost:9200"]
+    end
+
     def self.url(value=nil)
-      @url    = (value ? value.to_s.gsub(%r|/*$|, '') : nil) || @url || "http://localhost:9200"
+      urls([value])
+      @urls.respond_to?(:sample) ? @urls.sample : @urls.choice
     end
 
     def self.client(klass=nil)

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -33,17 +33,17 @@ module Tire
       end
 
       should "allow setting more URLS" do
-        assert_nothing_raised { Configuration.urls ['http://example1.com', 'http://example2.com'] }
+        assert_nothing_raised { Configuration.url 'http://example1.com', 'http://example2.com' }
         assert_equal ['http://example1.com', 'http://example2.com'], Configuration.urls
       end
 
       should "strip trailing slash from all the URLS" do
-        assert_nothing_raised { Configuration.urls ['http://slash1.com:9200/', 'http://slash2.com:9200/'] }
+        assert_nothing_raised { Configuration.url 'http://slash1.com:9200/', 'http://slash2.com:9200/' }
         assert_equal ['http://slash1.com:9200', 'http://slash2.com:9200'], Configuration.urls
       end
 
       should "retrieve a random URL from the ones available" do
-        assert_nothing_raised { Configuration.urls ['http://example1.com', 'http://example2.com'] }
+        assert_nothing_raised { Configuration.url 'http://example1.com', 'http://example2.com' }
         url = Configuration.url
         begin
           assert_equal 'http://example1.com', url

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -22,6 +22,11 @@ module Tire
         assert_equal 'http://localhost:9200', Configuration.url
       end
 
+      should "return default URL when URLS are empty" do
+        assert_nothing_raised { Configuration.url [] }
+        assert_equal 'http://localhost:9200', Configuration.url
+      end
+
       should "allow setting and retrieving the URL" do
         assert_nothing_raised { Configuration.url 'http://example.com' }
         assert_equal 'http://example.com', Configuration.url
@@ -38,7 +43,7 @@ module Tire
       end
 
       should "strip trailing slash from all the URLS" do
-        assert_nothing_raised { Configuration.url 'http://slash1.com:9200/', 'http://slash2.com:9200/' }
+        assert_nothing_raised { Configuration.url ['http://slash1.com:9200/', 'http://slash2.com:9200/'] }
         assert_equal ['http://slash1.com:9200', 'http://slash2.com:9200'], Configuration.urls
       end
 

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -32,6 +32,26 @@ module Tire
         assert_equal 'http://slash.com:9200', Configuration.url
       end
 
+      should "allow setting more URLS" do
+        assert_nothing_raised { Configuration.urls ['http://example1.com', 'http://example2.com'] }
+        assert_equal ['http://example1.com', 'http://example2.com'], Configuration.urls
+      end
+
+      should "strip trailing slash from all the URLS" do
+        assert_nothing_raised { Configuration.urls ['http://slash1.com:9200/', 'http://slash2.com:9200/'] }
+        assert_equal ['http://slash1.com:9200', 'http://slash2.com:9200'], Configuration.urls
+      end
+
+      should "retrieve a random URL from the ones available" do
+        assert_nothing_raised { Configuration.urls ['http://example1.com', 'http://example2.com'] }
+        url = Configuration.url
+        begin
+          assert_equal 'http://example1.com', url
+        rescue
+          assert_equal 'http://example2.com', url
+        end
+      end
+
       should "return default client" do
         assert_equal HTTP::Client::RestClient, Configuration.client
       end
@@ -49,7 +69,7 @@ module Tire
       should "allow to reset the configuration for specific property" do
         Configuration.url 'http://example.com'
         assert_equal      'http://example.com', Configuration.url
-        Configuration.reset :url
+        Configuration.reset :urls
         assert_equal      'http://localhost:9200', Configuration.url
       end
 


### PR DESCRIPTION
Currently Tire supports just one ElasticSearch url, it would be useful to support more and let it randomly use one of the available urls on requests (some kind of failover would be nice too, maybe next)
