### PR TITLE
Lazy loading of Searches only when #results or #response called

### DIFF
--- a/lib/tire/dsl.rb
+++ b/lib/tire/dsl.rb
@@ -7,7 +7,7 @@ module Tire
 
     def search(indices=nil, options={}, &block)
       if block_given?
-        Search::Search.new(indices, options, &block).perform
+        Search::Search.new(indices, options, &block)
       else
         payload = case options
           when Hash    then options.to_json

--- a/lib/tire/model/persistence/finders.rb
+++ b/lib/tire/model/persistence/finders.rb
@@ -21,7 +21,7 @@ module Tire
                   query.ids(args, document_type)
                 end
                 search.size args.size
-              end.perform.results
+              end.results
             else
               case args = args.pop
                 when Fixnum, String
@@ -41,7 +41,7 @@ module Tire
             old_wrapper = Tire::Configuration.wrapper
             Tire::Configuration.wrapper self
             s = Tire::Search::Search.new(index.name).query { all }
-            s.perform.results
+            s.results
           ensure
             Tire::Configuration.wrapper old_wrapper
           end
@@ -51,7 +51,7 @@ module Tire
             old_wrapper = Tire::Configuration.wrapper
             Tire::Configuration.wrapper self
             s = Tire::Search::Search.new(index.name).query { all }.size(1)
-            s.perform.results.first
+            s.results.first
           ensure
             Tire::Configuration.wrapper old_wrapper
           end

--- a/lib/tire/model/search.rb
+++ b/lib/tire/model/search.rb
@@ -94,7 +94,7 @@ module Tire
             s.fields Array(options[:fields]) if options[:fields]
           end
 
-          s.perform.results
+          s.results
         end
 
         # Returns a Tire::Index instance for this model.

--- a/lib/tire/search.rb
+++ b/lib/tire/search.rb
@@ -4,7 +4,7 @@ module Tire
   
     class Search
 
-      attr_reader :indices, :results, :response, :json, :query, :facets, :filters, :options
+      attr_reader :indices, :json, :query, :facets, :filters, :options
 
       def initialize(indices=nil, options = {}, &block)
         @indices = Array(indices)
@@ -14,6 +14,14 @@ module Tire
         @path    = ['/', @indices.join(','), @types.join(','), '_search'].compact.join('/').squeeze('/')
 
         block.arity < 1 ? instance_eval(&block) : block.call(self) if block_given?
+      end
+
+      def results
+        @results || (perform; @results)
+      end
+
+      def response
+        @response || (perform; @response)
       end
 
       def url

--- a/test/unit/tire_test.rb
+++ b/test/unit/tire_test.rb
@@ -53,6 +53,41 @@ module Tire
           end
         end
 
+        context "#search is lazy loaded and" do
+          def a_query
+            Tire.search 'dummy' do
+              query do
+                string "dummy"
+              end
+            end
+          end
+
+          should "not be called immediately" do
+            s = a_query
+            s.expects(:perform).never
+          end
+
+          should "be called by #perform" do
+            s = a_query
+            s.expects(:perform).once
+            s.perform
+          end
+
+          should "be called by #results" do
+            s = a_query
+            s.expects(:perform).once
+            s.results
+          end
+
+          should "allow search criteria to be chained" do
+            s = a_query
+            s.expects(:perform).once
+            s.filter :term, other_field: 'another dummy'
+            s.results
+          end
+
+        end
+
       end
 
     end


### PR DESCRIPTION
I had a use case in the DSL where a previously created query needed to be modified.

search = Tire.search 'test' do query { string 'some_field:some_value' } end   # don't perform the query yet

search.filter :terms, invite: ['yes']    # add an additional filter

search.results   #now execute the query (so that query is executed only once)

This commit adds this ability (it was easy to do) and includes specs. As a bonus, it replaces many instances of ".perform.results" with the more simple ".results"
