### PR TITLE
A couple of fixes for eager loading

### DIFF
--- a/lib/tire/model/naming.rb
+++ b/lib/tire/model/naming.rb
@@ -74,7 +74,7 @@ module Tire
         #
         def document_type name=nil
           @document_type = name if name
-          @document_type || klass.model_name.singular
+          @document_type || klass.model_name.underscore
         end
       end
 


### PR DESCRIPTION
Sorry, there was a bug in my previous pull-requested-commits, so here is the right one.

Tire.search (%w[red_things blue_things], :load=>true) do ...

Returns a mixed type collection that cannot be loaded by the current implementation. The first patch fixes it.

Besides, if you use nested model names (e.g. 'This::Thing') the model_name.singular returns a default document_type that is not usable to reconstruct the original class. Using 'underscore' instead of 'singular' fixes it.
