### PR TITLE
Search with version should set the version value in options

### DIFF
--- a/lib/tire/search.rb
+++ b/lib/tire/search.rb
@@ -69,6 +69,10 @@ module Tire
         self
       end
 
+      def version(value)
+        @version = value
+      end
+
       def perform
         @response = Configuration.client.get(self.url, self.to_json)
         if @response.failure?
@@ -97,6 +101,7 @@ module Tire
         request.update( { :size => @size } )               if @size
         request.update( { :from => @from } )               if @from
         request.update( { :fields => @fields } )           if @fields
+        request.update( { :version => @version } )         if @version
         request
       end
 

--- a/test/integration/query_return_version_test.rb
+++ b/test/integration/query_return_version_test.rb
@@ -1,0 +1,70 @@
+require 'test_helper'
+
+module Tire
+
+  class DslVersionIntegrationTest < Test::Unit::TestCase
+    include Test::Integration
+
+    context "DSL Version" do
+
+      setup do
+        Tire.index 'articles-test-ids' do
+          delete
+          create
+
+          store :id => 1, :title => 'One'
+          store :id => 2, :title => 'Two'
+
+          refresh
+        end
+      end
+
+      teardown { Tire.index('articles-test-ids').delete }
+
+      should "returns actual version (non-nil) value for records when 'version' is true" do
+        s = Tire.search('articles-test-ids') do
+          version true
+          query { string 'One' }
+        end
+
+        assert_equal 1, s.results.count
+
+        document = s.results.first
+        assert_equal 'One', document.title
+        assert_equal 1,      document._version.to_i
+
+      end
+
+      should "returns a nil version field when 'version' is false" do
+        s = Tire.search('articles-test-ids') do
+          version false
+          query { string 'One' }
+        end
+
+        assert_equal 1, s.results.count
+
+        document = s.results.first
+        assert_equal 'One', document.title
+        assert_equal nil,      document._version
+
+      end
+
+      should "returns a nil version field when 'version' is not included" do
+        s = Tire.search('articles-test-ids') do
+          query { string 'One' }
+        end
+
+        assert_equal 1, s.results.count
+
+        document = s.results.first
+        assert_equal 'One', document.title
+        assert_equal nil,      document._version
+
+      end
+
+    end
+
+  end
+
+end
+

--- a/test/unit/search_test.rb
+++ b/test/unit/search_test.rb
@@ -262,6 +262,18 @@ module Tire
 
       end
 
+      context "with version" do
+
+        should "set the version value in options" do
+          s = Search::Search.new('index') do
+            version true
+          end
+          hash = MultiJson.decode( s.to_json )
+          assert_equal true, hash['version']
+        end
+
+      end
+
       context "with from/size" do
 
         should "set the values in request" do


### PR DESCRIPTION
Adding 'version' to the DSL. Includes unit and integration tests. (thanks for Tire and Elasticsearch!)
