### PR TITLE
Kaminari-compatible import rake task

### DIFF
--- a/lib/tire/tasks.rb
+++ b/lib/tire/tasks.rb
@@ -67,6 +67,14 @@ namespace :tire do
 
     STDOUT.puts '-'*tty_cols
     elapsed = Benchmark.realtime do
+      if (!klass.respond_to?(:paginate) && klass.respond_to?(:page))
+        klass.instance_eval do
+          def paginate(options = {})
+            page(options[:page]).per(options[:per_page])
+          end
+        end
+      end
+      
       index.import(klass, 'paginate', params) do |documents|
 
         if total


### PR DESCRIPTION
Hi guys,
I've written a patch so the import rake task will support Kaminari out of the box, without adding the 'paginate' implementation into the model objects. Thanks a lot!
