### PR TITLE
Return nil from Index#retrieve when the document doesn't exist.

### DIFF
--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -152,10 +152,9 @@ module Tire
       h = MultiJson.decode(@response.body)
       if Configuration.wrapper == Hash then h
       else
-        document = {}
-        document = h['_source'] ? document.update( h['_source'] ) : document.update( h['fields'] )
+        document = h['_source'] || h['fields'] || {}
         document.update('id' => h['_id'], '_type' => h['_type'], '_index' => h['_index'], '_version' => h['_version'])
-        Configuration.wrapper.new(document)
+        h['exists'] != false ? Configuration.wrapper.new(document) : nil
       end
 
     ensure

--- a/test/unit/index_test.rb
+++ b/test/unit/index_test.rb
@@ -252,6 +252,13 @@ p response
           assert_equal 'Test', article.title
         end
 
+        should "return nil for missing document" do
+          Configuration.client.expects(:get).with("#{Configuration.url}/dummy/article/id-1").
+                                             returns(mock_response('{"_id":"id-1","exists":false}'))
+          article = @index.retrieve :article, 'id-1'
+          assert_equal nil, article
+        end
+
         should "raise error when no ID passed" do
           assert_raise ArgumentError do
             @index.retrieve 'article', nil


### PR DESCRIPTION
Previously an exception was raised on document.update(h['fields']) since h['field'] returned nil.

Here is a simple shell session that shows the data returned when a document is missing:

``` shell
$ curl -XPOST localhost:9200/empty
{"ok":true,"acknowledged":true}
$ curl -XGET localhost:9200/empty/message/1
{"_index":"empty","_type":"message","_id":"1","exists":false}
```
