### PR TITLE
Implement put mapping API.

### DIFF
--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -41,6 +41,20 @@ module Tire
       MultiJson.decode(@response.body)[@name]
     end
 
+    def update_mapping(mapping)
+      mapping.each do |type, value|
+        url, body = "#{Configuration.url}/#{@name}/#{type}/_mapping", MultiJson.encode(type => value)
+        begin
+          @response = Configuration.client.put url, body
+          raise RuntimeError, "#{@response.code} > #{@response.body}" if @response.failure?
+        ensure
+          curl = %Q|curl -X PUT "#{url}" -d '#{body}'|
+          logged('MAPPING', curl)
+        end
+      end
+      true
+    end
+
     def store(*args)
       document, options = args
       type = get_type_from_document(document)

--- a/test/unit/index_test.rb
+++ b/test/unit/index_test.rb
@@ -132,6 +132,16 @@ p response
           assert_equal 2.0,      @index.mapping['article']['properties']['title']['boost']
         end
 
+        should "update the mapping" do
+          Configuration.client.expects(:put).twice.returns(mock_response('{"ok":true,"acknowledged":true}'))
+
+          mapping = {
+            :article => { :properties => { :title => { :type => 'string', :boost => 2.0 } } },
+            :user => { :properties => { :name => { :type => 'string' } } },
+          }
+          assert @index.update_mapping mapping
+        end
+
       end
 
       context "when storing" do


### PR DESCRIPTION
http://www.elasticsearch.org/guide/reference/api/admin-indices-put-mapping.html

The mapping for all types can be set in the index creation request, but
the mapping for a single type must be updated per put mapping request.
