### PR TITLE
Escape the document types in case they are namespaced.

### DIFF
--- a/lib/tire.rb
+++ b/lib/tire.rb
@@ -2,6 +2,7 @@ require 'rest_client'
 require 'multi_json'
 require 'active_model'
 require 'hashr'
+require 'cgi'
 
 require 'tire/rubyext/hash'
 require 'tire/rubyext/symbol'

--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -275,7 +275,7 @@ module Tire
           document.type
         end
       $VERBOSE = old_verbose
-      type || :document
+      type ? CGI.escape(type.to_s) : :document
     end
 
     def get_id_from_document(document)

--- a/lib/tire/model/naming.rb
+++ b/lib/tire/model/naming.rb
@@ -74,7 +74,7 @@ module Tire
         #
         def document_type name=nil
           @document_type = name if name
-          @document_type || klass.model_name.singular
+          @document_type || klass.model_name.underscore
         end
       end
 

--- a/lib/tire/search.rb
+++ b/lib/tire/search.rb
@@ -8,7 +8,7 @@ module Tire
 
       def initialize(indices=nil, options = {}, &block)
         @indices = Array(indices)
-        @types   = Array(options.delete(:type))
+        @types   = Array(options.delete(:type)).map { |type| CGI.escape(type.to_s) }
         @options = options
 
         @path    = ['/', @indices.join(','), @types.join(','), '_search'].compact.join('/').squeeze('/')

--- a/test/models/namespaced_model.rb
+++ b/test/models/namespaced_model.rb
@@ -1,0 +1,8 @@
+# Example ActiveModel class with custom document type
+
+require File.expand_path('../active_model_article', __FILE__)
+
+module MyNamespace
+  class ModelInNamespace < ActiveModelArticle
+  end
+end

--- a/test/unit/index_test.rb
+++ b/test/unit/index_test.rb
@@ -173,6 +173,15 @@ module Tire
           @index.store article
         end
 
+        should "escape the namespaced type" do
+          article = MyNamespace::ModelInNamespace.new(:title => 'Test', :body => 'Lorem')
+
+          Configuration.client.expects(:post).with("#{Configuration.url}/dummy/my_namespace%2Fmodel_in_namespace/",
+                                                   article.to_indexed_json).
+            returns(mock_response('{"ok":true,"_id":"123"}'))
+          @index.store article
+        end
+
         should "set default type" do
           Configuration.client.expects(:post).with("#{Configuration.url}/dummy/document/", '{"title":"Test"}').returns(mock_response('{"ok":true,"_id":"test"}'))
           @index.store :title => 'Test'
@@ -273,6 +282,13 @@ module Tire
                                                 returns(mock_response('{"ok":true,"_id":"1"}')).twice
           @index.remove :id => 1, :type => 'article', :title => 'Test'
           @index.remove :id => 1, :type => 'article', :title => 'Test'
+        end
+
+        should "get namespaced type from document" do
+          Configuration.client.expects(:delete).with("#{Configuration.url}/dummy/articles%2Farticle/1").
+                                                returns(mock_response('{"ok":true,"_id":"1"}')).twice
+          @index.remove :id => 1, :type => 'articles/article', :title => 'Test'
+          @index.remove :id => 1, :type => 'articles/article', :title => 'Test'
         end
 
         should "set default type" do

--- a/test/unit/model_search_test.rb
+++ b/test/unit/model_search_test.rb
@@ -100,6 +100,13 @@ module Tire
           end
         end
 
+        should "properly translate namespaced model into document_type" do
+          # Watch out for <https://github.com/rails/rails/blob/v3.1.3/activemodel/lib/active_model/naming.rb#L50-52>
+          t = MyNamespace::ModelInNamespace.document_type
+          assert_equal 'my_namespace/model_in_namespace', t
+          assert defined?(t), "Cannot infer class from document type: #{t}"
+        end
+
         should "allow to refresh index" do
           Index.any_instance.expects(:refresh)
 

--- a/test/unit/search_test.rb
+++ b/test/unit/search_test.rb
@@ -35,6 +35,15 @@ module Tire
         assert_match %r|index/bar/_search|, s.url
       end
 
+      should "allow namespaced document types" do
+        types = ['article', 'articles/article']
+        s = Search::Search.new('index', :type => types) do
+          query { string 'foo' }
+        end
+
+        assert_match %r|index/article,articles%2Farticle/_search|, s.url
+      end
+
       should "allow to pass block to query" do
         Search::Query.any_instance.expects(:instance_eval)
 


### PR DESCRIPTION
Hi, we spotted the whole problem a few days ago and worked on it.
The patches I propose are the original one from @ddnexus and a patch of mine which escape types with corresponding tests. I ran the test suite and everything went fine.

Tell me if it's good enough for you :)
