### PR TITLE
Default document_type and index_name implementation 

### DIFF
--- a/lib/tire.rb
+++ b/lib/tire.rb
@@ -5,6 +5,7 @@ require 'hashr'
 
 require 'tire/rubyext/hash'
 require 'tire/rubyext/symbol'
+require 'tire/rubyext/string'
 require 'tire/logger'
 require 'tire/configuration'
 require 'tire/http/response'

--- a/lib/tire/model/naming.rb
+++ b/lib/tire/model/naming.rb
@@ -30,7 +30,7 @@ module Tire
         def index_name name=nil, &block
           @index_name = name if name
           @index_name = block if block_given?
-          @index_name || [index_prefix, klass.model_name.plural].compact.join('_')
+          @index_name || [index_prefix, klass.model_name.tableize.gsub('/', '__')].compact.join('_')
         end
 
         # Set or get index prefix for all models or for a specific model.
@@ -74,7 +74,7 @@ module Tire
         #
         def document_type name=nil
           @document_type = name if name
-          @document_type || klass.model_name.singular
+          @document_type || klass.model_name.underscore.gsub('/', '__')
         end
       end
 

--- a/lib/tire/results/collection.rb
+++ b/lib/tire/results/collection.rb
@@ -46,7 +46,7 @@ module Tire
                                  "document has no _type property." unless type
 
             begin
-              klass = type.camelize.constantize
+              klass = type.document_type_classify
             rescue NameError => e
               raise NameError, "You have tried to eager load the model instances, but " +
                                "Tire cannot find the model class '#{type.camelize}' " +

--- a/lib/tire/results/collection.rb
+++ b/lib/tire/results/collection.rb
@@ -46,7 +46,7 @@ module Tire
                                  "document has no _type property." unless type
 
             begin
-              klass = type.document_type_classify
+              klass = type.document_type_classify.constantize
             rescue NameError => e
               raise NameError, "You have tried to eager load the model instances, but " +
                                "Tire cannot find the model class '#{type.camelize}' " +

--- a/lib/tire/rubyext/string.rb
+++ b/lib/tire/rubyext/string.rb
@@ -1,0 +1,11 @@
+class String
+
+  def document_type_classify
+    gsub('__', '/').classify
+  end unless respond_to?(:tire_classify)
+
+  def index_name_classify(prefix=Tire::Model::Search.index_prefix + '_')
+    gsub(/^#{prefix}/, '').gsub('__', '/').classify
+  end unless respond_to?(:index_name_classify)
+
+end


### PR DESCRIPTION
This simple convention/conversion should be AR, ruby and URL friendly. It also keeps the index_prefix into consideration in case you want to classify an index with a prefix.
