### PR TITLE
Add alias support to indexes

### DIFF
--- a/lib/tire/dsl.rb
+++ b/lib/tire/dsl.rb
@@ -30,5 +30,15 @@ module Tire
       Index.new(name, &block)
     end
 
+    def aliases
+      @response = Configuration.client.get "#{Configuration.url}/_aliases"
+      MultiJson.decode(@response.body).inject({}) do |acc, (index, value)|
+        next acc if value['aliases'].empty?
+
+        acc[index] = value['aliases'].keys
+        acc
+      end
+    end
+
   end
 end

--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -36,6 +36,35 @@ module Tire
       logged('CREATE', curl)
     end
 
+    def add_alias(alias_name)
+      operation = {'actions' => [{'add' => {'index' => @name, 'alias' => alias_name}}]}
+      @response = Configuration.client.post "#{Configuration.url}/_aliases", MultiJson.encode(operation)
+      @response.success?
+
+    ensure
+      curl = %Q|curl -X POST "#{Configuration.url}/_aliases -d '#{MultiJson.encode(operation)}'"|
+      logged('POST', curl)
+    end
+
+    def remove_alias(alias_name)
+      operation = {'actions' => [{'remove' => {'index' => @name, 'alias' => alias_name}}]}
+      @response = Configuration.client.post "#{Configuration.url}/_aliases", MultiJson.encode(operation)
+      @response.success?
+
+    ensure
+      curl = %Q|curl -X POST "#{Configuration.url}/_aliases -d '#{MultiJson.encode(operation)}'"|
+      logged('POST', curl)
+    end
+
+    def aliases(alias_name = nil)
+      @response = Configuration.client.get "#{Configuration.url}/#{@name}/_aliases"
+      if alias_name
+        MultiJson.decode(@response.body)[@name]['aliases'].try(:[], alias_name)
+      else
+        MultiJson.decode(@response.body)[@name]['aliases'].keys
+      end
+    end
+
     def mapping
       @response = Configuration.client.get("#{Configuration.url}/#{@name}/_mapping")
       MultiJson.decode(@response.body)[@name]

--- a/test/unit/index_test.rb
+++ b/test/unit/index_test.rb
@@ -44,6 +44,36 @@ module Tire
         assert_nothing_raised { assert ! @index.delete }
       end
 
+      should "add an index alias" do
+        Configuration.client.expects(:post).with do |url, payload|
+          assert_equal({'actions' => [{'add' => {'index' => 'dummy', 'alias' => 'foo'}}]}.to_json, payload)
+        end.returns(mock_response('{"ok":true}'))
+
+        @index.add_alias('foo')
+      end
+
+      should "delete an index alias" do
+        Configuration.client.expects(:post).with do |url, payload|
+          assert_equal({'actions' => [{'remove' => {'index' => 'dummy', 'alias' => 'foo'}}]}.to_json, payload)
+        end.returns(mock_response('{"ok":true}'))
+
+        @index.remove_alias('foo')
+      end
+
+      should "list aliases on an index" do
+        json = {'dummy' => {'aliases' => {'foo' => {}}}}.to_json
+        Configuration.client.expects(:get).returns(mock_response(json))
+
+        assert_equal(['foo'], @index.aliases)
+      end
+
+      should "get the properties of an alias" do
+        json = {'dummy' => {'aliases' => {'foo' => {'some_config' => 'bar'}}}}.to_json
+        Configuration.client.expects(:get).returns(mock_response(json))
+
+        assert_equal({'some_config' => 'bar'}, @index.aliases('foo'))
+      end
+
       should "refresh the index" do
         Configuration.client.expects(:post).returns(mock_response('{"ok":true,"_shards":{}}'))
         assert_nothing_raised { assert @index.refresh }

--- a/test/unit/tire_test.rb
+++ b/test/unit/tire_test.rb
@@ -68,6 +68,13 @@ module Tire
 
         end
 
+        should "list all aliases" do
+          json = {'dummy' => {'aliases' => {'foo' => {}}}}.to_json
+          Configuration.client.expects(:get).returns(mock_response(json))
+
+          assert_equal({'dummy' => ['foo']}, Tire.aliases)
+        end
+
       end
 
     end


### PR DESCRIPTION
Adds:
- Tire::aliases
- Tire::Index#aliases
- Tire::Index#add_alias
- Tire::Index#remove_alias

Among other uses for aliases, this enables on-the-fly index rotation
scripting.

I wasn't sure what your stance on integration tests are, and/or whether you would want integration tests for these. Unit tests are included, though.

I have a couple other methods that round out the on-the-fly index rotation implementation, https://gist.github.com/1634344, but didn't include them here because reindex is ActiveRecord specific and inverted_aliases' name I'm not confident about.

Opinions/thoughts?
