### PR TITLE
Support any level of mappings

### DIFF
--- a/lib/tire/model/indexing.rb
+++ b/lib/tire/model/indexing.rb
@@ -76,21 +76,21 @@ module Tire
         # for more information.
         #
         def indexes(name, options = {}, &block)
+          mapping[name] = options
+
           if block_given?
-            mapping[name] ||= { :type => 'object', :properties => {} }.update(options)
-            @_nested_mapping = name
-            nested = yield
-            @_nested_mapping = nil
-            self
-          else
-            options[:type] ||= 'string'
-            if @_nested_mapping
-              mapping[@_nested_mapping][:properties][name] = options
-            else
-              mapping[name] = options
-            end
-            self
+            mapping[name][:type]       ||= 'object'
+            mapping[name][:properties] ||= {}
+
+            previous = @mapping
+            @mapping = mapping[name][:properties]
+            yield
+            @mapping = previous
           end
+
+          mapping[name][:type] ||= 'string'
+
+          self
         end
 
         # Creates the corresponding index with desired settings and mappings, when it does not exists yet.

--- a/test/unit/model_search_test.rb
+++ b/test/unit/model_search_test.rb
@@ -357,7 +357,13 @@ module Tire
                     :type => 'object',
                     :properties => {
                       :first_name => { :type => 'string' },
-                      :last_name  => { :type => 'string', :boost => 100 }
+                      :last_name  => { :type => 'string', :boost => 100 },
+                      :posts => {
+                        :type => 'object',
+                        :properties => {
+                          :title  => { :type => 'string', :boost => 10 }
+                        }
+                      }
                     }
                   }
                 }
@@ -378,6 +384,10 @@ module Tire
                 indexes :author do
                   indexes :first_name, :type => 'string'
                   indexes :last_name,  :type => 'string', :boost => 100
+
+                  indexes :posts do
+                    indexes :title, :type => 'string', :boost => 10
+                  end
                 end
               end
 
@@ -385,6 +395,7 @@ module Tire
 
             assert_not_nil ModelWithNestedMapping.mapping[:author][:properties][:last_name]
             assert_equal   100, ModelWithNestedMapping.mapping[:author][:properties][:last_name][:boost]
+            assert_equal   10, ModelWithNestedMapping.mapping[:author][:properties][:posts][:properties][:title][:boost]
           end
 
           should "define mapping for nested documents" do


### PR DESCRIPTION
Previously, only two levels of mappings were supported, ex:

```
mapping do
  indexes :title, :type => 'string'
  indexes :author do
    indexes :first_name, :type => 'string'
    indexes :last_name,  :type => 'string', :boost => 100
  end
end
```

This commit adds support for any level of mappings, ex:

```
mapping do
  indexes :title, :type => 'string'
  indexes :author do
    indexes :first_name, :type => 'string'
    indexes :last_name,  :type => 'string', :boost => 100

    indexes :posts do
      indexes :title, :type => 'string', :boost => 10
    end
  end
end
```
