### PR TITLE
ActiveRecord Single Table Inheritance search bug

### DIFF
--- a/test/integration/active_record_searchable_test.rb
+++ b/test/integration/active_record_searchable_test.rb
@@ -32,6 +32,10 @@ module Tire
         create_table :active_record_class_with_dynamic_index_names do |t|
           t.string     :title
         end
+        create_table :sti_ancestors do |t|
+          t.string :title
+          t.string :type
+        end
       end
     end
 
@@ -350,6 +354,26 @@ module Tire
           @item.load(:include => 'comments')
         end
 
+      end
+
+      context 'with Single Table Inheritance' do
+        setup do
+          StiAncestor.create! :title => 'Ancestor text'
+          FirstStiDescendant.create! :title => 'Descendant text'
+          SecondStiDescendant.create! :title => 'Another Descendant text'
+        end
+
+        should 'load all STI descendants items' do
+          res = Tire.search('sti_ancestors', :load => true) do
+            query do
+              string 'Descendant'
+            end
+          end.results.results
+
+          assert_length_of res.results, 2
+          assert_instance_of FirstStiDescendant, res[0]
+          assert_instance_of SecondStiDescendant, res[1]
+        end
       end
 
     end

--- a/test/integration/active_record_searchable_test.rb
+++ b/test/integration/active_record_searchable_test.rb
@@ -368,9 +368,9 @@ module Tire
             query do
               string 'Descendant'
             end
-          end.results.results
+          end.results
 
-          assert_length_of res.results, 2
+          assert_equal 2, res.length
           assert_instance_of FirstStiDescendant, res[0]
           assert_instance_of SecondStiDescendant, res[1]
         end

--- a/test/models/active_record_models.rb
+++ b/test/models/active_record_models.rb
@@ -78,3 +78,16 @@ class ActiveRecordClassWithDynamicIndexName < ActiveRecord::Base
     "dynamic" + '_' + "index"
   end
 end
+
+class StiAncestor < ActiveRecord::Base
+  include Tire::Model::Search
+  include Tire::Model::Callbacks
+end
+
+class FirstStiDescendant < StiAncestor
+  index_name 'sti_ancestors'
+end
+
+class SecondStiDescendant < StiAncestor
+  index_name 'sti_ancestors'
+end


### PR DESCRIPTION
When I need to make a search on STI ancestor (to get mixed results from all descendants) on one index (like in tests), I was usually getting error, because it makes 'find' from wrong class. Well, you can see it in tests.

Also it repaires one more bug: when you have two STI classes with separate indexes (like in default) and try to make a search like Tire.search('first_table_index,second_table_index', :load => true) { ... }, it also raises RecordNotFound.
