### PR TITLE
Only retry Tire::Index#bulk_store on StandardError.

### DIFF
--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -85,7 +85,7 @@ module Tire
         response = Configuration.client.post("#{Configuration.url}/_bulk", payload.join("\n"))
         raise RuntimeError, "#{response.code} > #{response.body}" if response.failure?
         response
-      rescue Exception => error
+      rescue StandardError => error
         if count < tries
           count += 1
           STDERR.puts "[ERROR] #{error.message}, retrying (#{count})..."

--- a/test/unit/index_test.rb
+++ b/test/unit/index_test.rb
@@ -353,10 +353,24 @@ module Tire
 
         end
 
-        should "try again when an exception occurs" do
+        should "try again when an error response is received" do
           Configuration.client.expects(:post).returns(mock_response('Server error', 503)).at_least(2)
 
           assert !@index.bulk_store([ {:id => '1', :title => 'One'}, {:id => '2', :title => 'Two'} ])
+        end
+
+        should "try again when an connection error occurs" do
+          Configuration.client.expects(:post).raises(Errno::ECONNREFUSED, "Connection refused - connect(2)").at_least(2)
+
+          assert !@index.bulk_store([ {:id => '1', :title => 'One'}, {:id => '2', :title => 'Two'} ])
+        end
+
+        should "signal exceptions should not be caught" do
+          Configuration.client.expects(:post).raises(Interrupt, "abort then interrupt!")
+
+          assert_raise Interrupt do
+            @index.bulk_store([ {:id => '1', :title => 'One'}, {:id => '2', :title => 'Two'} ])
+          end
         end
 
         should "display error message when collection item does not have ID" do

--- a/test/unit/index_test.rb
+++ b/test/unit/index_test.rb
@@ -359,7 +359,7 @@ module Tire
           assert !@index.bulk_store([ {:id => '1', :title => 'One'}, {:id => '2', :title => 'Two'} ])
         end
 
-        should "try again when an connection error occurs" do
+        should "try again when a connection error occurs" do
           Configuration.client.expects(:post).raises(Errno::ECONNREFUSED, "Connection refused - connect(2)").at_least(2)
 
           assert !@index.bulk_store([ {:id => '1', :title => 'One'}, {:id => '2', :title => 'Two'} ])


### PR DESCRIPTION
Otherwise bulk_store retries after receiving signals like INT or TERM, likely resulting in the process getting killing by the KILL signal (if being terminated automatically) without executing normal cleanup (e.g. ensure blocks).
