### PR TITLE
[BULK] Raise instead of just writing to stderr

### DIFF
--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -92,6 +92,7 @@ module Tire
           retry
         else
           STDERR.puts "[ERROR] Too many exceptions occured, giving up. The HTTP response was: #{error.message}"
+          raise
         end
 
       ensure

--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -64,7 +64,7 @@ module Tire
       logged([type, id].join('/'), curl)
     end
 
-    def bulk_store documents
+    def bulk_store(documents, options={})
       payload = documents.map do |document|
         id   = get_id_from_document(document)
         type = get_type_from_document(document)
@@ -92,7 +92,7 @@ module Tire
           retry
         else
           STDERR.puts "[ERROR] Too many exceptions occured, giving up. The HTTP response was: #{error.message}"
-          raise
+          raise if options[:raise]
         end
 
       ensure
@@ -110,13 +110,13 @@ module Tire
 
             documents = yield documents if block_given?
 
-            bulk_store documents
+            bulk_store documents, options.slice(:raise)
             options[:page] += 1
           end
 
         when klass_or_collection.respond_to?(:map)
           documents = block_given? ? yield(klass_or_collection) : klass_or_collection
-          bulk_store documents
+          bulk_store documents, options.slice(:raise)
 
         else
           raise ArgumentError, "Please pass either a collection of objects, " +

--- a/test/unit/index_test.rb
+++ b/test/unit/index_test.rb
@@ -353,10 +353,12 @@ module Tire
 
         end
 
-        should "try again when an exception occurs" do
+        should "try again and then raise when an exception occurs" do
           Configuration.client.expects(:post).returns(mock_response('Server error', 503)).at_least(2)
 
-          assert !@index.bulk_store([ {:id => '1', :title => 'One'}, {:id => '2', :title => 'Two'} ])
+          assert_raise(RuntimeError) do
+            @index.bulk_store([ {:id => '1', :title => 'One'}, {:id => '2', :title => 'Two'} ])
+          end
         end
 
         should "display error message when collection item does not have ID" do

--- a/test/unit/model_import_test.rb
+++ b/test/unit/model_import_test.rb
@@ -39,8 +39,8 @@ module Tire
         end
 
         should "call the passed block on every batch, and NOT manipulate the documents array" do
-          Tire::Index.any_instance.expects(:bulk_store).with([1, 2])
-          Tire::Index.any_instance.expects(:bulk_store).with([3, 4])
+          Tire::Index.any_instance.expects(:bulk_store).with([1, 2], options={})
+          Tire::Index.any_instance.expects(:bulk_store).with([3, 4], options={})
 
           runs = 0
           ImportModel.import :per_page => 2 do |documents|
@@ -53,8 +53,8 @@ module Tire
         end
 
         should "manipulate the documents in passed block" do
-          Tire::Index.any_instance.expects(:bulk_store).with([2, 3])
-          Tire::Index.any_instance.expects(:bulk_store).with([4, 5])
+          Tire::Index.any_instance.expects(:bulk_store).with([2, 3], options={})
+          Tire::Index.any_instance.expects(:bulk_store).with([4, 5], options={})
 
           ImportModel.import :per_page => 2 do |documents|
             # Add 1 to every "document" and return them


### PR DESCRIPTION
I happen to have a lot of documents missing, because Tire does not raise in case of failure during a bulk insertions. I think the problem is important enough to be considered as a raised exception.
In my case, my bulk insertions are triggered by Resque jobs. Without an exception, I cannot retry failed jobs.
