### PR TITLE
Avoiding conflict with meta_search (or other gems) when it overrides the search method.

### DIFF
--- a/lib/tire/model/search.rb
+++ b/lib/tire/model/search.rb
@@ -63,6 +63,10 @@ module Tire
         #     Article.search :load => { :include => 'comments' } do ... end
         #
         def search(*args, &block)
+          search_with_tire(*args, &block)
+        end
+        
+        def search_with_tire(*args, &block)
           default_options = {:type => document_type, :index => index.name}
 
           if block_given?


### PR DESCRIPTION
Hi there karmi and vhyza!

First of all, thanks for this wonderful gem.
I've been using it in a project that also uses the "meta_search" gem, but this one overrides the search method that Tire declares.

I've simply rename the tire search method to "search_with_tire" and declared the search method like so:
        def search(_args, &block)
          search_with_tire(_args, &block)
        end
This keeps the standard behavior intact and allows people like me to acces the tire search method with an alternative call: "search_with_tire".

The changes are fairly simple, could you guys incorporate them in your master version?
I prefer to use your gem instead of my forked one.

Cheers.
