### PR TITLE
Prefer ELASTICSEARCH_URL as a default, if present.

### DIFF
--- a/lib/tire/configuration.rb
+++ b/lib/tire/configuration.rb
@@ -3,7 +3,8 @@ module Tire
   class Configuration
 
     def self.url(value=nil)
-      @url    = (value ? value.to_s.gsub(%r|/*$|, '') : nil) || @url || "http://localhost:9200"
+      @url = (value ? value.to_s.gsub(%r|/*$|, '') : nil) || @url ||
+              ENV['ELASTICSEARCH_URL'] || "http://localhost:9200"
     end
 
     def self.client(klass=nil)


### PR DESCRIPTION
If the ELASTICSEARCH_URL environment variable is present, prefer that as a default value when a url is not otherwise supplied. This is my take on #240 for trivial Heroku integration.

I implemented this in the GitHub web based editor, so may be worth running your specs against this change before considering a merge ;)
