### PR TITLE
Support for ElasticSearch's 'explain' => true in query and '_explanation' field in the resulting items

### DIFF
--- a/lib/tire/model/persistence.rb
+++ b/lib/tire/model/persistence.rb
@@ -45,7 +45,7 @@ module Tire
 
           include Persistence::Storage
 
-          ['_score', '_type', '_index', '_version', 'sort', 'highlight', 'matches'].each do |attr|
+          ['_score', '_type', '_index', '_version', 'sort', 'highlight', 'matches', '_explanation'].each do |attr|
             define_method("#{attr}=") { |value| @attributes ||= {}; @attributes[attr] = value }
             define_method("#{attr}")  { @attributes[attr] }
           end

--- a/lib/tire/results/collection.rb
+++ b/lib/tire/results/collection.rb
@@ -31,7 +31,7 @@ module Tire
                  document.update( {'id' => h['_id']} )
 
                  # Update the document with meta information
-                 ['_score', '_type', '_index', '_version', 'sort', 'highlight'].each { |key| document.update( {key => h[key]} || {} ) }
+                 ['_score', '_type', '_index', '_version', 'sort', 'highlight', '_explanation'].each { |key| document.update( {key => h[key]} || {} ) }
 
                  # Return an instance of the "wrapper" class
                  @wrapper.new(document)

--- a/lib/tire/search.rb
+++ b/lib/tire/search.rb
@@ -4,7 +4,7 @@ module Tire
   
     class Search
 
-      attr_reader :indices, :json, :query, :facets, :filters, :options
+      attr_reader :indices, :json, :query, :facets, :filters, :options, :explain
 
       def initialize(indices=nil, options = {}, &block)
         @indices = Array(indices)
@@ -76,6 +76,11 @@ module Tire
         @fields = Array(fields.flatten)
         self
       end
+      
+      def explain(value)
+        @explain = value
+        self
+      end
 
       def perform
         @response = Configuration.client.get(self.url, self.to_json)
@@ -105,6 +110,7 @@ module Tire
         request.update( { :size => @size } )               if @size
         request.update( { :from => @from } )               if @from
         request.update( { :fields => @fields } )           if @fields
+        request.update( { :explain => @explain } )         if @explain
         request
       end
 

--- a/test/integration/explanation_test.rb
+++ b/test/integration/explanation_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+module Tire
+
+  class ExplanationIntegrationTest < Test::Unit::TestCase
+    include Test::Integration
+
+    context "Explanation" do
+      teardown { Tire.index('explanation-test').delete }
+
+      setup do
+        content = "A Fox one day fell into a deep well and could find no means of escape. A Goat, overcome with thirst, came to the same well, and seeing the Fox, inquired if the water was good. Concealing his sad plight under a merry guise, the Fox indulged in a lavish praise of the water, saying it was excellent beyond measure, and encouraging him to descend. The Goat, mindful only of his thirst, thoughtlessly jumped down, but just as he drank, the Fox informed him of the difficulty they were both in and suggested a scheme for their common escape. \"If,\" said he, \"you will place your forefeet upon the wall and bend your head, I will run up your back and escape, and will help you out afterwards.\" The Goat readily assented and the Fox leaped upon his back. Steadying himself with the Goat horns, he safely reached the mouth of the well and made off as fast as he could. When the Goat upbraided him for breaking his promise, he turned around and cried out, \"You foolish old fellow! If you had as many brains in your head as you have hairs in your beard, you would never have gone down before you had inspected the way up, nor have exposed yourself to dangers from which you had no means of escape.\" Look before you leap."
+
+        Tire.index 'explanation-test' do
+          delete
+          create
+          store   :id => 1, :content => content
+          refresh
+        end
+      end
+
+      should "add '_explanation' field to the result item" do
+        # Tire::Configuration.logger STDERR, :level => 'debug'
+        s = Tire.search('explanation-test') do
+          query do
+            boolean do
+              should   { string 'content:Fox' }
+            end
+          end
+          explain :true
+        end
+
+        doc = s.results.first
+
+        explanation = doc._explanation
+        
+        assert explanation.description.include?("product of:")
+        assert explanation.value < 0.6
+        assert_not_nil explanation.details
+        end
+
+      end
+
+    end
+  end

--- a/test/unit/search_test.rb
+++ b/test/unit/search_test.rb
@@ -331,6 +331,33 @@ module Tire
 
       end
 
+      context "explain" do
+
+        should "default to false" do
+          s = Search::Search.new('index') do
+          end
+          hash = MultiJson.decode( s.to_json )
+          assert_nil hash['explain']
+        end
+
+        should "set the explain field in the request when true" do
+          s = Search::Search.new('index') do
+            explain true
+          end
+          hash = MultiJson.decode( s.to_json )
+          assert_equal true, hash['explain']
+        end
+
+        should "not set the explain field when false" do
+          s = Search::Search.new('index') do
+            explain false
+          end
+          hash = MultiJson.decode( s.to_json )
+          assert_nil hash['explain']
+        end
+
+      end
+
       context "boolean queries" do
 
         should "wrap other queries" do

--- a/tire.gemspec
+++ b/tire.gemspec
@@ -43,6 +43,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "supermodel",   "~> 0.1.6"
   s.add_development_dependency "curb"
+  s.add_development_dependency "minitest"
 
   # These gems are not needed for CI at <http://travis-ci.org/#!/karmi/tire>
   #


### PR DESCRIPTION
This commit includes unit tests, an integration test and an implementation for turning on the explanation field with the scoring breakdown. 

This is useful when developing user-interfaces for building and exploring search queries.

Usage:

``` ruby
        s = Tire.search('explanation-test') do
          query { string 'content:Fox' }
          explain true
        end
```

Which enables the '_explanation' attribute on each result item, accessible so:

``` ruby
s.results.first._explanation
```
