### PR TITLE
Bulk 'create' indexing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.un~
 *.gem
 .bundle
 Gemfile.lock

--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -310,14 +310,15 @@ module Tire
         id   = get_id_from_document(document)
         type = get_type_from_document(document)
         parent = get_parent_from_document(document)
-        STDERR.puts "[ERROR] Document #{document.inspect} does not have ID" unless id
 
-        meta_hash = {op_type => { '_index'=>@name, '_type'=>type, '_id'=>id}}
+        meta_hash = { '_index' => @name, '_type' => type}
+        meta_hash['_id'] = id if id
+        meta_hash['_parent'] = parent if parent
 
-        meta_hash[op_type]['_parent'] = parent if parent
+        action_meta_hash = {op_type => meta_hash}
 
-        meta_json = meta_hash.to_json
-        return meta_json
+        action_meta_json = action_meta_hash.to_json
+        return action_meta_json
     end
 
   end

--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -70,6 +70,7 @@ module Tire
       payload = documents.map do |document|
         id   = get_id_from_document(document)
         type = get_type_from_document(document)
+        parent = get_parent_from_document(document)
 
         STDERR.puts "[ERROR] Document #{document.inspect} does not have ID" unless id
 
@@ -262,6 +263,10 @@ module Tire
 
         Configuration.logger.log_response code, nil, body
       end
+    end
+
+    def get_parent_from_document(document)
+      'implement me'
     end
 
     def get_type_from_document(document)

--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -65,7 +65,7 @@ module Tire
     end
 
     def bulk_store(documents, options = {})
-      options.merge({:method => "index"}) unless options[:method]
+      options.merge!({:method => "index"}) unless options[:method]
 
       payload = documents.map do |document|
         id   = get_id_from_document(document)

--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -75,7 +75,11 @@ module Tire
         STDERR.puts "[ERROR] Document #{document.inspect} does not have ID" unless id
 
         output = []
-        output << %Q|{"#{options[:method]}":{"_index":"#{@name}","_type":"#{type}","_id":"#{id}"}}|
+        if parent
+          output << %Q|{"#{options[:method]}":{"_index":"#{@name}","_type":"#{type}","_id":"#{id}","_parent":"#{parent}"}}|
+        else
+          output << %Q|{"#{options[:method]}":{"_index":"#{@name}","_type":"#{type}","_id":"#{id}"}}|
+        end
         output << convert_document_to_json(document)
         output.join("\n")
       end
@@ -266,7 +270,15 @@ module Tire
     end
 
     def get_parent_from_document(document)
-      'implement me'
+      old_verbose, $VERBOSE = $VERBOSE, nil # Silence Object#type deprecation warnings
+      parent = case
+             when document.is_a?(Hash)
+               document[:_parent] || document['_parent'] || document[:parent] || document['parent']
+             when document.respond_to?(:_parent)
+               document.parent
+             end
+      $VERBOSE = old_verbose
+      parent
     end
 
     def get_type_from_document(document)

--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -261,14 +261,12 @@ module Tire
     end
 
     def get_parent_from_document(document)
-      old_verbose, $VERBOSE = $VERBOSE, nil # Silence Object#type deprecation warnings
       parent = case
              when document.is_a?(Hash)
                document[:_parent] || document['_parent'] || document[:parent] || document['parent']
-             when document.respond_to?(:_parent)
+             when document.respond_to?(:parent)
                document.parent
              end
-      $VERBOSE = old_verbose
       parent
     end
 

--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -64,7 +64,9 @@ module Tire
       logged([type, id].join('/'), curl)
     end
 
-    def bulk_store documents
+    def bulk_store(documents, options = {})
+      options.merge({:method => "index"}) unless options[:method]
+
       payload = documents.map do |document|
         id   = get_id_from_document(document)
         type = get_type_from_document(document)
@@ -72,7 +74,7 @@ module Tire
         STDERR.puts "[ERROR] Document #{document.inspect} does not have ID" unless id
 
         output = []
-        output << %Q|{"index":{"_index":"#{@name}","_type":"#{type}","_id":"#{id}"}}|
+        output << %Q|{"#{options[:method]}":{"_index":"#{@name}","_type":"#{type}","_id":"#{id}"}}|
         output << convert_document_to_json(document)
         output.join("\n")
       end

--- a/test/unit/bulk_index_without_id.rb
+++ b/test/unit/bulk_index_without_id.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+module Tire
+
+  class CreateTest < Test::Unit::TestCase
+
+    context "Create" do
+
+      setup do
+        @index = Tire::Index.new 'dummy'
+      end
+
+      should "bulk store should not be dependent on the presence of an _id parameter" do
+        Configuration.client.expects(:post).with do |url, json|
+          url  == "#{Configuration.url}/_bulk" &&
+          json !~ /_id/
+        end.returns(mock_response('{}'), 200)
+
+        @index.bulk_store [ {:title => 'One'}, {:title => 'Two'} ]
+      end
+    end
+  end
+end
+

--- a/test/unit/bulk_parent_test.rb
+++ b/test/unit/bulk_parent_test.rb
@@ -33,7 +33,14 @@ module Tire
         @index.bulk_store [ {:id => '1', :title => 'One', :_parent => "abcdef", :type => "blog_tag"}, {:id => '2', :title => 'Two', :type => "blog_tag", :_parent => "qwerty"} ]
       end
 
-      should "bulk store should handle the 'parent' field"
+      should "bulk store should handle the 'parent' field" do
+        Configuration.client.expects(:post).with do |url, json|
+          url  == "#{Configuration.url}/_bulk" &&
+            json =~ /\A{.*?"_parent":"abcdef".*?}}/
+        end.returns(mock_response('{}'), 200)
+
+          @index.bulk_store [ {:id => '1', :title => 'One', :parent => "abcdef", :type => "blog_tag"}, {:id => '2', :title => 'Two', :type => "blog_tag", :parent => "qwerty"} ]
+      end
     end
   end
 end

--- a/test/unit/bulk_parent_test.rb
+++ b/test/unit/bulk_parent_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+
+module Tire
+
+  class CreateTest < Test::Unit::TestCase
+
+    context "Bulk Parent" do
+
+      setup do
+        @index = Tire::Index.new 'dummy'
+        Tire.index 'dummy' do
+          create :mappings => {
+            :blog => {
+              :properties => {
+                :text => "string"
+              }
+            },
+            :blog_tag => {
+                :_parent => {
+                  :type => "blog"
+                }
+              }
+            }
+        end
+      end
+
+      should "bulk store should handle the '_parent' field" do
+        Configuration.client.expects(:post).with do |url, json|
+          url  == "#{Configuration.url}/_bulk" &&
+          json =~ /\A{.*?"_parent":"abcdef".*?}}/
+        end.returns(mock_response('{}'), 200)
+
+        @index.bulk_store [ {:id => '1', :title => 'One', :_parent => "abcdef", :type => "blog_tag"}, {:id => '2', :title => 'Two', :type => "blog_tag", :_parent => "qwerty"} ]
+      end
+
+      should "bulk store should handle the 'parent' field"
+    end
+  end
+end
+

--- a/test/unit/create_test.rb
+++ b/test/unit/create_test.rb
@@ -10,10 +10,10 @@ module Tire
         @index = Tire::Index.new 'dummy'
       end
 
-      should "have a name" do
+      should "bulk store should accept method argument" do
         Configuration.client.expects(:post).with do |url, json|
           url  == "#{Configuration.url}/_bulk" &&
-          json =~ /\A{"create": .*}}\Z/
+          json =~ /\A{"create":.*?}}/
         end.returns(mock_response('{}'), 200)
 
         @index.bulk_store [ {:id => '1', :title => 'One'}, {:id => '2', :title => 'Two'} ], method: 'create'

--- a/test/unit/create_test.rb
+++ b/test/unit/create_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+module Tire
+
+  class CreateTest < Test::Unit::TestCase
+
+    context "Create" do
+
+      setup do
+        @index = Tire::Index.new 'dummy'
+      end
+
+      should "have a name" do
+        Configuration.client.expects(:post).with do |url, json|
+          url  == "#{Configuration.url}/_bulk" &&
+          json =~ /\A{"create": .*}}\Z/
+        end.returns(mock_response('{}'), 200)
+
+        @index.bulk_store [ {:id => '1', :title => 'One'}, {:id => '2', :title => 'Two'} ], method: 'create'
+      end
+    end
+  end
+end

--- a/test/unit/index_test.rb
+++ b/test/unit/index_test.rb
@@ -321,6 +321,7 @@ module Tire
         should "serialize Hashes" do
           Configuration.client.expects(:post).with do |url, json|
             url  == "#{Configuration.url}/_bulk" &&
+            json =~ /{"index":{/ &&
             json =~ /"_index":"dummy"/ &&
             json =~ /"_type":"document"/ &&
             json =~ /"_id":"1"/ &&


### PR DESCRIPTION
Hi,

I have extended the bulk_store method to accept an optional hash argument. When the options hash contains a :method key the value of this key is used to signal the kind of bulk indexing which should be done ('create' in this instance).

I included a test in it's own separate file as I was unsure where to include it in the existing test library (probably in test/unit/index.rb).

This feature is build on the latest master and should apply cleanly.

With kind regards,
