### PR TITLE
Tire::Index#store supports the "parent" option

### DIFF
--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -48,13 +48,20 @@ module Tire
       if options
         percolate = options[:percolate]
         percolate = "*" if percolate === true
+        parent = options[:parent]
       end
 
       id       = get_id_from_document(document)
       document = convert_document_to_json(document)
 
       url  = id ? "#{Configuration.url}/#{@name}/#{type}/#{id}" : "#{Configuration.url}/#{@name}/#{type}/"
-      url += "?percolate=#{percolate}" if percolate
+
+      if percolate || parent
+        query_string = []
+        query_string << "percolate=#{percolate}" if percolate
+        query_string << "parent=#{parent}" if parent
+        url += "?" + query_string.join("&")
+      end
 
       @response = Configuration.client.post url, document
       MultiJson.decode(@response.body)

--- a/test/unit/index_test.rb
+++ b/test/unit/index_test.rb
@@ -178,6 +178,15 @@ module Tire
           @index.store :title => 'Test'
         end
 
+        context "with the :parent option" do
+
+          should "set the :parent option in the query string" do
+            Configuration.client.expects(:post).with("#{Configuration.url}/dummy/document/?parent=1234", '{"title":"Test"}').returns(mock_response('{"ok":true,"_id":"test"}'))
+            @index.store({:title => 'Test'}, {:parent => 1234})
+          end
+
+        end
+
         should "call #to_indexed_json on non-String documents" do
           document = { :title => 'Test' }
           Configuration.client.expects(:post).returns(mock_response('{"ok":true,"_id":"test"}'))


### PR DESCRIPTION
Hi there, Karel. This pull request enables users to store documents in a parent-child relationship.

`Tire::Index#store` can be told to set the `parent` option in the query string. Eg:

``` ruby
Product.tire.index.store doc, :parent => doc.parent.id
```
