### PR TITLE
Fix Tire.search with a payload rather than a block.

### DIFF
--- a/lib/tire/dsl.rb
+++ b/lib/tire/dsl.rb
@@ -20,7 +20,7 @@ module Tire
         end
 
         search = Search::Search.new(indices, options) { |search| nil }
-        response = Configuration.client.post search.url, payload
+        response = Configuration.client.get search.url, payload
         raise Tire::Search::SearchRequestFailed, response.to_s if response.failure?
         json     = MultiJson.decode(response.body)
         results  = Results::Collection.new(json, options)

--- a/lib/tire/dsl.rb
+++ b/lib/tire/dsl.rb
@@ -9,13 +9,18 @@ module Tire
       if block_given?
         Search::Search.new(indices, options, &block)
       else
-        payload = case options
-          when Hash    then options.to_json
-          when String  then options
+        case options
+          when Hash    then
+            payload = (options[:payload] || options).to_json
+            options = {} unless options.delete(:payload)
+          when String  then
+            payload = options
+            options = {}
           else raise ArgumentError, "Please pass a Ruby Hash or String with JSON"
         end
 
-        response = Configuration.client.post( "#{Configuration.url}/#{indices}/_search", payload)
+        search = Search::Search.new(indices, options) { |search| nil }
+        response = Configuration.client.post search.url, payload
         raise Tire::Search::SearchRequestFailed, response.to_s if response.failure?
         json     = MultiJson.decode(response.body)
         results  = Results::Collection.new(json, options)

--- a/test/unit/tire_test.rb
+++ b/test/unit/tire_test.rb
@@ -23,7 +23,7 @@ module Tire
         end
 
         should "allow searching with a Ruby Hash" do
-          Tire::Configuration.client.expects(:post).
+          Tire::Configuration.client.expects(:get).
             with('http://localhost:9200/dummy/_search','{"query":{"query_string":{"query":"foo"}}}').
             returns( mock_response('{}') )
           Tire::Results::Collection.expects(:new).with({}, {})
@@ -32,7 +32,7 @@ module Tire
         end
 
         should "allow searching with a payload option" do
-          Tire::Configuration.client.expects(:post).
+          Tire::Configuration.client.expects(:get).
             with('http://localhost:9200/dummy/_search','{"query":{"query_string":{"query":"foo"}}}').
             returns( mock_response('{}') )
           Tire::Results::Collection.expects(:new).with({}, { :load => true })
@@ -41,7 +41,7 @@ module Tire
         end
 
         should "allow searching on a specific type with a payload option" do
-          Tire::Configuration.client.expects(:post).
+          Tire::Configuration.client.expects(:get).
             with('http://localhost:9200/dummy/doctype/_search','{"query":{"query_string":{"query":"foo"}}}').
             returns( mock_response('{}') )
           Tire::Results::Collection.expects(:new).with({}, {})
@@ -50,7 +50,7 @@ module Tire
         end
 
         should "allow searching with a JSON string" do
-          Tire::Configuration.client.expects(:post).
+          Tire::Configuration.client.expects(:get).
             with('http://localhost:9200/dummy/_search','{"query":{"query_string":{"query":"foo"}}}').
             returns( mock_response('{}') )
           Tire::Results::Collection.expects(:new).with({}, {})
@@ -66,7 +66,7 @@ module Tire
 
         should "raise SearchRequestFailed when receiving bad response from backend" do
           assert_raise(Search::SearchRequestFailed) do
-            Tire::Configuration.client.expects(:post).returns( mock_response('INDEX DOES NOT EXIST', 404) )
+            Tire::Configuration.client.expects(:get).returns( mock_response('INDEX DOES NOT EXIST', 404) )
             Tire.search 'not-existing', :query => { :query_string => { :query => 'foo' }}
           end
         end

--- a/test/unit/tire_test.rb
+++ b/test/unit/tire_test.rb
@@ -26,16 +26,34 @@ module Tire
           Tire::Configuration.client.expects(:post).
             with('http://localhost:9200/dummy/_search','{"query":{"query_string":{"query":"foo"}}}').
             returns( mock_response('{}') )
-          Tire::Results::Collection.expects(:new)
+          Tire::Results::Collection.expects(:new).with({}, {})
 
           Tire.search 'dummy', :query => { :query_string => { :query => 'foo' }}
+        end
+
+        should "allow searching with a payload option" do
+          Tire::Configuration.client.expects(:post).
+            with('http://localhost:9200/dummy/_search','{"query":{"query_string":{"query":"foo"}}}').
+            returns( mock_response('{}') )
+          Tire::Results::Collection.expects(:new).with({}, { :load => true })
+
+          Tire.search 'dummy', :payload => { :query => { :query_string => { :query => 'foo' }}}, :load => true
+        end
+
+        should "allow searching on a specific type with a payload option" do
+          Tire::Configuration.client.expects(:post).
+            with('http://localhost:9200/dummy/doctype/_search','{"query":{"query_string":{"query":"foo"}}}').
+            returns( mock_response('{}') )
+          Tire::Results::Collection.expects(:new).with({}, {})
+
+          Tire.search 'dummy', :payload => { :query => { :query_string => { :query => 'foo' }}}, :type => 'doctype'
         end
 
         should "allow searching with a JSON string" do
           Tire::Configuration.client.expects(:post).
             with('http://localhost:9200/dummy/_search','{"query":{"query_string":{"query":"foo"}}}').
             returns( mock_response('{}') )
-          Tire::Results::Collection.expects(:new)
+          Tire::Results::Collection.expects(:new).with({}, {})
 
           Tire.search 'dummy', '{"query":{"query_string":{"query":"foo"}}}'
         end


### PR DESCRIPTION
Previously calling Tire.search with a string payload would cause an exception to be raised in Tire::Results::Collection, since the payload was passed directly into the Collection.new options parameter.

Passing any options to Tire.search would result in those options being encoded directly in the body of the search, causing the search to fail.

This also resulted in missing functionality for Tire.search with a payload, since options couldn't be specified, such as the document type. This commit adds support for this through specifying the search body in a payload option, then recognizing additional options supported by Tire.search with a block.
