### PR TITLE
fixed #264 "You have tried to eager load the model instances..."

### DIFF
--- a/lib/tire/results/collection.rb
+++ b/lib/tire/results/collection.rb
@@ -47,9 +47,9 @@ module Tire
 
             begin
               explicit_class_name = @options[:class_name]
-              klass = explicit_class_name.nil? ? type.camelize.constantize : @options[:class_name].constantize
+              klass = explicit_class_name.nil? ? type.camelize.constantize : explicit_class_name.constantize
             rescue NameError => e
-              class_name, class_source = if @options[:class_name].nil?
+              class_name, class_source = if explicit_class_name.nil?
                 [type.camelize, "_type #{type}"]
               else
                 [explicit_class_name, "class_name #{explicit_class_name}"]

--- a/lib/tire/results/collection.rb
+++ b/lib/tire/results/collection.rb
@@ -49,7 +49,7 @@ module Tire
               explicit_class_name = @options[:class_name]
               klass = explicit_class_name.nil? ? type.camelize.constantize : @options[:class_name].constantize
             rescue NameError => e
-              class_name, type_source = if @options[:class_name].nil?
+              class_name, class_source = if @options[:class_name].nil?
                 [type.camelize, "_type #{type}"]
               else
                 [explicit_class_name, "class_name #{explicit_class_name}"]
@@ -57,7 +57,7 @@ module Tire
 
               raise NameError, "You have tried to eager load the model instances, but " +
                                "Tire cannot find the model class '#{class_name}' " +
-                               "based on '#{type_source}'.", e.backtrace
+                               "based on '#{class_source}'.", e.backtrace
             end
 
             ids   = @response['hits']['hits'].map { |h| h['_id'] }

--- a/lib/tire/results/collection.rb
+++ b/lib/tire/results/collection.rb
@@ -46,7 +46,7 @@ module Tire
                                  "document has no _type property." unless type
 
             begin
-              klass = type.camelize.constantize
+              klass = @options[:class_name].nil? ? type.camelize.constantize : @options[:class_name].constantize
             rescue NameError => e
               raise NameError, "You have tried to eager load the model instances, but " +
                                "Tire cannot find the model class '#{type.camelize}' " +

--- a/lib/tire/results/collection.rb
+++ b/lib/tire/results/collection.rb
@@ -46,11 +46,18 @@ module Tire
                                  "document has no _type property." unless type
 
             begin
-              klass = @options[:class_name].nil? ? type.camelize.constantize : @options[:class_name].constantize
+              explicit_class_name = @options[:class_name]
+              klass = explicit_class_name.nil? ? type.camelize.constantize : @options[:class_name].constantize
             rescue NameError => e
+              class_name, type_source = if @options[:class_name].nil?
+                [type.camelize, "_type #{type}"]
+              else
+                [explicit_class_name, "class_name #{explicit_class_name}"]
+              end
+
               raise NameError, "You have tried to eager load the model instances, but " +
-                               "Tire cannot find the model class '#{type.camelize}' " +
-                               "based on _type '#{type}'.", e.backtrace
+                               "Tire cannot find the model class '#{class_name}' " +
+                               "based on '#{type_source}'.", e.backtrace
             end
 
             ids   = @response['hits']['hits'].map { |h| h['_id'] }

--- a/test/unit/results_collection_test.rb
+++ b/test/unit/results_collection_test.rb
@@ -254,6 +254,27 @@ module Tire
           end
         end
 
+        should "raise error when _type does not reflect a constant name in the library" do
+          assert_raise(NameError) do
+            missing_constant = "some_missing_constant"
+            missing_constant.expects(:camelize).at_least_once
+            response = { 'hits' => { 'hits' => [ {'_id' => 1, '_type' => missing_constant}] } }
+            Results::Collection.new(response, :load => true).results
+          end
+        end
+
+        context "class_name explicitely specified" do
+          should "not raise error when _type does not reflect a constant name in the library" do
+            class_name = "SomeClass"
+            constantized_class_name = mock()
+
+            class_name.expects(:constantize).returns(constantized_class_name)
+            constantized_class_name.expects(:find).returns([])
+            options = {:load => true, :class_name => class_name}
+            Results::Collection.new(@response, options).results
+          end
+        end
+
         should "return empty array for empty hits" do
           response = { 'hits'  => {
                          'hits' => [],


### PR DESCRIPTION
This allows us to specify an explicit model name when calling tire.search or from the DSL itself
e.g. tire.search(load: true, class_name: 'My::ClassName') { ... }
