### PR TITLE
Don't use to_sym in Tire::Results::Item, as keys from elastic search might provide from user input

### DIFF
--- a/lib/tire/results/item.rb
+++ b/lib/tire/results/item.rb
@@ -13,9 +13,9 @@ module Tire
         @attributes = {}
         args.each_pair do |key, value|
           if value.is_a?(Array)
-            @attributes[key.to_sym] = value.map { |item| @attributes[key.to_sym] = item.is_a?(Hash) ? Item.new(item.to_hash) : item }
+            @attributes[key.to_s] = value.map { |item| @attributes[key.to_s] = item.is_a?(Hash) ? Item.new(item.to_hash) : item }
           else
-            @attributes[key.to_sym] = value.is_a?(Hash) ? Item.new(value.to_hash) : value
+            @attributes[key.to_s] = value.is_a?(Hash) ? Item.new(value.to_hash) : value
           end
         end
       end
@@ -24,15 +24,15 @@ module Tire
       # otherwise return +nil+.
       #
       def method_missing(method_name, *arguments)
-        @attributes.has_key?(method_name.to_sym) ? @attributes[method_name.to_sym] : nil
+        @attributes.has_key?(method_name.to_s) ? @attributes[method_name.to_s] : nil
       end
 
       def [](key)
-        @attributes[key]
+        @attributes[key.to_s]
       end
 
       def id
-        @attributes[:_id] || @attributes[:id]
+        @attributes['_id'] || @attributes['id']
       end
 
       def persisted?
@@ -58,7 +58,7 @@ module Tire
       # Let's pretend we're someone else in Rails
       #
       def class
-        defined?(::Rails) && @attributes[:_type] ? @attributes[:_type].camelize.constantize : super
+        defined?(::Rails) && @attributes['_type'] ? @attributes['_type'].camelize.constantize : super
       rescue NameError
         super
       end


### PR DESCRIPTION
Hi,

I see that Tire::Results::Item calls to_sym on every key-value pair retrieved from ElasticSearch.

I have an app where a user has sites on a map, and every site can have a bunch of user-defined properties. Those properties with their values get stored in ElasticSearch.

When those properties are retrieved from ElasticSearch they are first converted to Symbols. **This is a memory leak, because Symbols are never released. So, a malicious user could potentially generate sites with randomly generated user-defined properties, and so the memory will be filled of Symbols.**

In general, it's never good to use to_sym from user generated data.

The commit I made just used to_s instead. Since ElasticSearch already returns the json keys as strings, calling to_s just returns the string itself. When indexing by a symbol, I also invoke to_s, so that would be the only "performance problem" (but later that string can be freed).
