### PR TITLE
Add ability to override to_param for Results::Item

### DIFF
--- a/lib/tire/results/item.rb
+++ b/lib/tire/results/item.rb
@@ -51,6 +51,10 @@ module Tire
         persisted? ? [id] : nil
       end
 
+      def to_param
+        @attributes[:to_param] || [id] if persisted?
+      end
+
       def to_hash
         @attributes
       end


### PR DESCRIPTION
I wanted to be able to send a Results::Item directly to a named route like

```
  video_path(result)
```

for a model with to_param redefined to a "friendly string".  I wanted to ability to specify a to_param attribute.  I'm not sure if there's a preferred way to do this, but this patch works for me.
