### PR TITLE
Add support for ElasticSearch's Update API, new in 0.19

### DIFF
--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -240,6 +240,15 @@ module Tire
       logged('_percolate', curl)
     end
 
+    def update(type, id, options={})
+      @response = Configuration.client.post "#{Configuration.url}/#{@name}/#{type}/#{id}/_update", MultiJson.encode(options)
+      @response.success? ? @response : false
+
+    ensure
+      curl = %Q|curl -X POST "#{Configuration.url}/#{@name}/#{type}/#{id}/_update?pretty=1" -d '#{options.to_json}'|
+      logged('_update', curl)
+    end
+
     def logged(endpoint='/', curl='')
       if Configuration.logger
         error = $!


### PR DESCRIPTION
Using the Update API you don't have re-index the entire document, you can just set the fields that have changed with the new value, and the re-indexing is done on the server.
