### PR TITLE
Make Item#[] call 'to_sym' on supplied key to better support multi_value fields

### DIFF
--- a/lib/tire/results/item.rb
+++ b/lib/tire/results/item.rb
@@ -28,7 +28,7 @@ module Tire
       end
 
       def [](key)
-        @attributes[key]
+        @attributes[key.to_sym]
       end
 
       def id


### PR DESCRIPTION
Given a multi_field `name` with sub field `ngrams` and a query which highlights `name.ngrams`, if we try to use the highlight with `result.highlight['name.ngrams']` we'll get `nil` even though inspect shows `<Item name.ngrams: [".."]>`. Doing `result.highlight['name.ngrams'.to_sym]` works as expected, but tire should do this for us.
