### PR TITLE
fuzzy query dsl support + term api improvement

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -298,6 +298,18 @@ a plain old Ruby `Hash` (or JSON string) with the query declaration to the `sear
     Tire.search 'articles', :query => { :fuzzy => { :title => 'Sour' } }
 ```
 
+... but you can also do fuzzy querys using our API:
+
+```ruby
+    Tire.search('articles') { query { fuzzy :title, 'Sour' } }
+```
+
+Tire also allow you to customize the fuzzy call by passsing an options hash:
+
+```ruby
+    Tire.search('articles') { query { fuzzy :title, 'Sour', { boost: 2, min_similarity: 0.5 } } }
+```
+
 If this sounds like a great idea to you, you are probably able to write your application
 using just `curl`, `sed` and `awk`.
 

--- a/README.markdown
+++ b/README.markdown
@@ -307,7 +307,7 @@ a plain old Ruby `Hash` (or JSON string) with the query declaration to the `sear
 Tire also allow you to customize the fuzzy call by passsing an options hash:
 
 ```ruby
-    Tire.search('articles') { query { fuzzy :title, 'Sour', { boost: 2, min_similarity: 0.5 } } }
+    Tire.search('articles') { query { fuzzy :title, 'Sour', boost: 2, min_similarity: 0.5 } }
 ```
 
 If this sounds like a great idea to you, you are probably able to write your application

--- a/examples/tire-dsl.rb
+++ b/examples/tire-dsl.rb
@@ -483,6 +483,7 @@ end
 # * [custom_score](http://www.elasticsearch.org/guide/reference/query-dsl/custom-score-query.html)
 # * [all](http://www.elasticsearch.org/guide/reference/query-dsl/match-all-query.html)
 # * [ids](http://www.elasticsearch.org/guide/reference/query-dsl/ids-query.html)
+# * [fuzzy](http://www.elasticsearch.org/guide/reference/query-dsl/fuzzy-query.html)
 
 #### Faceted Search
 

--- a/lib/tire/search/query.rb
+++ b/lib/tire/search/query.rb
@@ -7,8 +7,16 @@ module Tire
         block.arity < 1 ? self.instance_eval(&block) : block.call(self) if block_given?
       end
 
-      def term(field, value)
-        @value = { :term => { field => value } }
+      def term(field, value, options={})
+        query = { field => { :term => value } }
+        query[field].update(options)
+        @value = { :term => query }
+      end
+
+      def fuzzy(field, value, options={})
+        query = { field => { :term => value } }
+        query[field].update(options)
+        @value = { :fuzzy => query }
       end
 
       def terms(field, value, options={})

--- a/test/integration/fuzzy_queries_test.rb
+++ b/test/integration/fuzzy_queries_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+module Tire
+
+  class FuzzyQueryIntegrationTest < Test::Unit::TestCase
+    include Test::Integration
+
+    context "Fuzzy query" do
+      should "fuzzily find article by tag" do
+        results = Tire.search('articles-test') { query { fuzzy :tags, 'irlang' } }.results
+
+        assert_equal 1,        results.count
+        assert_equal ["erlang"], results.first[:tags]
+      end
+
+    end
+
+  end
+
+end

--- a/test/unit/search_query_test.rb
+++ b/test/unit/search_query_test.rb
@@ -25,6 +25,10 @@ module Tire::Search
         assert_equal( { :term => { :foo => { :term => 'bar' } } }, Query.new.term(:foo, 'bar') )
       end
 
+      should "allow search for single term passing an options hash" do
+        assert_equal( { :term => { :foo => { :term => 'bar', :boost => 2.0 } } }, Query.new.term(:foo, 'bar', :boost => 2.0) )
+      end
+
       should "allow search for multiple terms" do
         assert_equal( { :terms => { :foo => ['bar', 'baz'] } }, Query.new.terms(:foo, ['bar', 'baz']) )
       end
@@ -92,6 +96,18 @@ module Tire::Search
       should "search for documents by IDs" do
         assert_equal( { :ids => { :values => [1, 2], :type => 'foo' }  },
                       Query.new.ids([1, 2], 'foo') )
+      end
+
+    end
+    
+    context "FuzzyQuery" do
+
+      should "allow a fuzzy search" do
+        assert_equal( { :fuzzy => { :foo => { :term => 'bar' } } }, Query.new.fuzzy(:foo, 'bar') )
+      end
+
+      should "allow a fuzzy search with an options hash" do
+        assert_equal( { :term => { :foo => { :term => 'bar', :boost => 1.0, :min_similarity => 0.5 } } }, Query.new.term(:foo, 'bar', :boost => 1.0, :min_similarity => 0.5 ) )
       end
 
     end

--- a/test/unit/search_query_test.rb
+++ b/test/unit/search_query_test.rb
@@ -12,17 +12,17 @@ module Tire::Search
 
       should "return itself as a Hash" do
         assert_respond_to Query.new, :to_hash
-        assert_equal( { :term => { :foo => 'bar' } }, Query.new.term(:foo, 'bar').to_hash )
+        assert_equal( { :term => { :foo => { :term => 'bar' } } }, Query.new.term(:foo, 'bar').to_hash )
       end
 
       should "allow a block to be given" do
-        assert_equal( { :term => { :foo => 'bar' } }.to_json, Query.new do
+        assert_equal( { :term => { :foo => { :term => 'bar' } } }.to_json, Query.new do
           term(:foo, 'bar')
         end.to_json)
       end
 
       should "allow search for single term" do
-        assert_equal( { :term => { :foo => 'bar' } }, Query.new.term(:foo, 'bar') )
+        assert_equal( { :term => { :foo => { :term => 'bar' } } }, Query.new.term(:foo, 'bar') )
       end
 
       should "allow search for multiple terms" do
@@ -173,7 +173,7 @@ module Tire::Search
         end
 
         query[:filtered].tap do |f|
-          assert_equal( { :term => { :foo => 'bar' } }, f[:query].to_hash )
+          assert_equal( { :term => { :foo => { :term => 'bar' } } }, f[:query].to_hash )
           assert_equal( { :tags => ['ruby'] }, f[:filter][:and].first[:terms] )
         end
       end
@@ -202,7 +202,7 @@ module Tire::Search
         end
 
         query[:filtered].tap do |f|
-          assert_equal( { :term => { :foo => 'bar' } }, f[:query].to_hash )
+          assert_equal( { :term => { :foo => { :term => 'bar' } } }, f[:query].to_hash )
           assert_equal( { :tags => ['ruby'] }, f[:filter][:and].first[:terms] )
         end
       end


### PR DESCRIPTION
For newcomers(like me - but not [just](http://stackoverflow.com/questions/9018291/rewrite-sql-query-with-tire) me), It's pretty hard to find out how to add support to [fuzzy](http://www.elasticsearch.org/guide/reference/query-dsl/fuzzy-query.html) searchs. It would be nicer to have some api to easier archive querys with fuzzy(and maybe [flt](http://www.elasticsearch.org/guide/reference/query-dsl/flt-query.html)).

disclaimer: I know that `Tire.search 'customers', :query => { :fuzzy => { :name => 'John' } }` work, but it's pretty hard to include things like pagination, etc.

this is an initial implementation and could be improved. I also added a little improvement to the `term` api, which allow a option's hash parameter to be passed.
