### PR TITLE
Added Custom Filters Score Query support

### DIFF
--- a/lib/tire/search/query.rb
+++ b/lib/tire/search/query.rb
@@ -210,7 +210,9 @@ module Tire
       end
       
       def to_hash
-        @value
+        @value[:filters].present? ? 
+        @value : 
+        @value.merge(:filters => [{ :filter => { :match_all => {}}, :boost => 1.0 }])
       end
       
       def to_json

--- a/lib/tire/search/query.rb
+++ b/lib/tire/search/query.rb
@@ -59,6 +59,14 @@ module Tire
         @value[:filtered] = @filtered.to_hash
         @value
       end
+      
+      def custom_filters_score(&block)
+        @custom_filters_score = CustomFiltersScoreQuery.new
+        block.arity < 1 ? @custom_filters_score.instance_eval(&block) : block.call(@custom_filters_score) if
+          block_given?
+        @value[:custom_filters_score] = @custom_filters_score.to_hash
+        @value
+      end
 
       def all
         @value = { :match_all => {} }
@@ -142,6 +150,69 @@ module Tire
         @value
       end
 
+      def to_json
+        to_hash.to_json
+      end
+    end
+    
+    class CustomFiltersScoreQuery
+      class CustomFilter
+        def initialize(&block)
+          @value = {}
+          block.arity < 1 ? self.instance_eval(&block) : block.call(self) if block_given?
+        end
+        
+        def filter(type, *options)
+          @value[:filter] = Filter.new(type, *options).to_hash
+          @value
+        end
+        
+        def boost(value)
+          @value[:boost] = value
+          @value
+        end
+        
+        def script(value)
+          @value[:script] = value
+          @value
+        end
+        
+        def to_hash
+          @value
+        end
+
+        def to_json
+          to_hash.to_json
+        end
+      end
+      
+      def initialize(&block)
+        @value = {}
+        block.arity < 1 ? self.instance_eval(&block) : block.call(self) if block_given?
+      end
+      
+      def query(options={}, &block)
+        @value[:query] = Query.new(&block).to_hash
+        @value
+      end
+      
+      def filter(&block)
+        custom_filter = CustomFilter.new
+        block.arity < 1 ? custom_filter.instance_eval(&block) : block.call(custom_filter) if block_given?
+        @value[:filters] ||= []
+        @value[:filters] << custom_filter.to_hash
+        @value
+      end
+      
+      def score_mode(value)
+        @value[:score_mode] = value
+        @value
+      end
+      
+      def to_hash
+        @value
+      end
+      
       def to_json
         to_hash.to_json
       end

--- a/lib/tire/search/query.rb
+++ b/lib/tire/search/query.rb
@@ -212,7 +212,7 @@ module Tire
       def to_hash
         @value[:filters].present? ? 
         @value : 
-        @value.merge(:filters => [{ :filter => { :match_all => {}}, :boost => 1.0 }])
+        @value.merge(:filters => [CustomFilter.new{ filter(:match_all); boost(1) }.to_hash]) # Needs at least one filter
       end
       
       def to_json

--- a/test/unit/search_query_test.rb
+++ b/test/unit/search_query_test.rb
@@ -237,6 +237,80 @@ module Tire::Search
       end
 
     end
+    
+    context "CustomFiltersScoreQuery" do
+
+      should "not raise an error when no block is given" do
+        assert_nothing_raised { Query.new.custom_filters_score }
+      end
+
+      should "properly encode filter with boost" do
+        query = Query.new.custom_filters_score do
+          query { term :foo, 'bar' }
+          filter do
+            filter :terms, :tags => ['ruby']
+            boost '2.0'
+          end
+        end
+
+        query[:custom_filters_score].tap do |f|
+          assert_equal( { :term => { :foo => { :term => 'bar' } } }, f[:query].to_hash )
+          assert_equal( { :tags => ['ruby'] }, f[:filters].first[:filter][:terms])
+          assert_equal( '2.0', f[:filters].first[:boost])
+        end
+      end
+      
+      should "properly encode filter with script" do
+        query = Query.new.custom_filters_score do
+          query { term :foo, 'bar' }
+          filter do
+            filter :terms, :tags => ['ruby']
+            script '_score * 2.0'
+          end
+        end
+
+        query[:custom_filters_score].tap do |f|
+          assert_equal( { :term => { :foo => { :term => 'bar' } } }, f[:query].to_hash )
+          assert_equal( { :tags => ['ruby'] }, f[:filters].first[:filter][:terms])
+          assert_equal( '_score * 2.0', f[:filters].first[:script])
+        end
+      end
+
+      should "properly encode multiple filters" do
+        query = Query.new.custom_filters_score do
+          query { term :foo, 'bar' }
+          filter do
+            filter :terms, :tags => ['ruby']
+            boost '2.0'
+          end
+          filter do
+            filter :terms, :tags => ['python']
+            script '_score * 2.0'
+          end
+        end
+        
+        query[:custom_filters_score].tap do |f|
+          assert_equal( { :term => { :foo => { :term => 'bar' } } }, f[:query].to_hash )
+          assert_equal( { :tags => ['ruby'] }, f[:filters].first[:filter][:terms])
+          assert_equal( '2.0', f[:filters].first[:boost])
+          assert_equal( { :tags => ['python'] }, f[:filters].last[:filter][:terms])
+          assert_equal( '_score * 2.0', f[:filters].last[:script])
+        end
+      end
+      
+      should "allow setting the score_mode" do
+        query = Query.new.custom_filters_score do
+          query { term :foo, 'bar' }
+          score_mode 'total'
+        end
+
+        query[:custom_filters_score].tap do |f|
+          assert_equal( { :term => { :foo => { :term => 'bar' } } }, f[:query].to_hash )
+          assert_equal( 'total', f[:score_mode])
+        end
+      end
+
+    end
   end
 
 end

--- a/test/unit/search_query_test.rb
+++ b/test/unit/search_query_test.rb
@@ -243,20 +243,32 @@ module Tire::Search
       should "not raise an error when no block is given" do
         assert_nothing_raised { Query.new.custom_filters_score }
       end
+      
+      should "provides a default filter if no filter is given" do
+        query = Query.new.custom_filters_score do
+          query { term :foo, 'bar' }
+        end
+
+        query[:custom_filters_score].tap do |f|
+          assert_equal( { :term => { :foo => { :term => 'bar' } } }, f[:query].to_hash )
+          assert_equal( { :match_all => {} }, f[:filters].first[:filter])
+          assert_equal( 1.0, f[:filters].first[:boost])
+        end
+      end
 
       should "properly encode filter with boost" do
         query = Query.new.custom_filters_score do
           query { term :foo, 'bar' }
           filter do
             filter :terms, :tags => ['ruby']
-            boost '2.0'
+            boost 2.0
           end
         end
 
         query[:custom_filters_score].tap do |f|
           assert_equal( { :term => { :foo => { :term => 'bar' } } }, f[:query].to_hash )
           assert_equal( { :tags => ['ruby'] }, f[:filters].first[:filter][:terms])
-          assert_equal( '2.0', f[:filters].first[:boost])
+          assert_equal( 2.0, f[:filters].first[:boost])
         end
       end
       
@@ -281,7 +293,7 @@ module Tire::Search
           query { term :foo, 'bar' }
           filter do
             filter :terms, :tags => ['ruby']
-            boost '2.0'
+            boost 2.0
           end
           filter do
             filter :terms, :tags => ['python']
@@ -292,7 +304,7 @@ module Tire::Search
         query[:custom_filters_score].tap do |f|
           assert_equal( { :term => { :foo => { :term => 'bar' } } }, f[:query].to_hash )
           assert_equal( { :tags => ['ruby'] }, f[:filters].first[:filter][:terms])
-          assert_equal( '2.0', f[:filters].first[:boost])
+          assert_equal( 2.0, f[:filters].first[:boost])
           assert_equal( { :tags => ['python'] }, f[:filters].last[:filter][:terms])
           assert_equal( '_score * 2.0', f[:filters].last[:script])
         end


### PR DESCRIPTION
karmi,
Thanks for the wonderful library. Since we need to use Custom Filters Score Query for our project, we decided to go ahead and added the changes necessary for supporting Custom Filters Score Query. Here is how would an user to use it:

Model.tire.search(:load => true) do
  query do
    custom_filters_score do
      query { string query }
      filter do
        filter :term, :tags => "ruby"
        boost 2.0 # script "..." is also supported
      end
      score_mode "total"
    end
  end
end

We also added the test cases for it. We would like to contribute this back to the community, please let us know if there is any changes you would like us to make.

Thanks again.
- Jerry
