### PR TITLE
Updated multijson deprecations introduced in MultiJson 1.3

### DIFF
--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -38,12 +38,12 @@ module Tire
 
     def mapping
       @response = Configuration.client.get("#{Configuration.url}/#{@name}/_mapping")
-      MultiJson.decode(@response.body)[@name]
+      MultiJson.load(@response.body)[@name]
     end
 
     def settings
       @response = Configuration.client.get("#{Configuration.url}/#{@name}/_settings")
-      MultiJson.decode(@response.body)[@name]['settings']
+      MultiJson.load(@response.body)[@name]['settings']
     end
 
     def store(*args)
@@ -62,7 +62,7 @@ module Tire
       url += "?percolate=#{percolate}" if percolate
 
       @response = Configuration.client.post url, document
-      MultiJson.decode(@response.body)
+      MultiJson.load(@response.body)
 
     ensure
       curl = %Q|curl -X POST "#{url}" -d '#{document}'|
@@ -154,7 +154,7 @@ module Tire
 
       url    = "#{Configuration.url}/#{@name}/#{type}/#{id}"
       result = Configuration.client.delete url
-      MultiJson.decode(result.body) if result.success?
+      MultiJson.load(result.body) if result.success?
 
     ensure
       curl = %Q|curl -X DELETE "#{url}"|
@@ -168,7 +168,7 @@ module Tire
       url       = "#{Configuration.url}/#{@name}/#{type}/#{id}"
       @response = Configuration.client.get url
 
-      h = MultiJson.decode(@response.body)
+      h = MultiJson.load(@response.body)
       if Configuration.wrapper == Hash then h
       else
         return nil if h['exists'] == false
@@ -193,7 +193,7 @@ module Tire
     def open(options={})
       # TODO: Remove the duplication in the execute > rescue > ensure chain
       @response = Configuration.client.post "#{Configuration.url}/#{@name}/_open", MultiJson.dump(options)
-      MultiJson.decode(@response.body)['ok']
+      MultiJson.load(@response.body)['ok']
 
     ensure
       curl = %Q|curl -X POST "#{Configuration.url}/#{@name}/_open"|
@@ -202,7 +202,7 @@ module Tire
 
     def close(options={})
       @response = Configuration.client.post "#{Configuration.url}/#{@name}/_close", MultiJson.dump(options)
-      MultiJson.decode(@response.body)['ok']
+      MultiJson.load(@response.body)['ok']
 
     ensure
       curl = %Q|curl -X POST "#{Configuration.url}/#{@name}/_close"|
@@ -213,7 +213,7 @@ module Tire
       options = {:pretty => true}.update(options)
       params  = options.to_param
       @response = Configuration.client.get "#{Configuration.url}/#{@name}/_analyze?#{params}", text
-      @response.success? ? MultiJson.decode(@response.body) : false
+      @response.success? ? MultiJson.load(@response.body) : false
 
     ensure
       curl = %Q|curl -X GET "#{Configuration.url}/#{@name}/_analyze?#{params}" -d '#{text}'|
@@ -224,7 +224,7 @@ module Tire
       options[:query] = Search::Query.new(&block).to_hash if block_given?
 
       @response = Configuration.client.put "#{Configuration.url}/_percolator/#{@name}/#{name}", MultiJson.dump(options)
-      MultiJson.decode(@response.body)['ok']
+      MultiJson.load(@response.body)['ok']
 
     ensure
       curl = %Q|curl -X PUT "#{Configuration.url}/_percolator/#{@name}/?pretty=1" -d '#{MultiJson.dump(options)}'|
@@ -233,7 +233,7 @@ module Tire
 
     def unregister_percolator_query(name)
       @response = Configuration.client.delete "#{Configuration.url}/_percolator/#{@name}/#{name}"
-      MultiJson.decode(@response.body)['ok']
+      MultiJson.load(@response.body)['ok']
 
     ensure
       curl = %Q|curl -X DELETE "#{Configuration.url}/_percolator/#{@name}"|
@@ -244,7 +244,7 @@ module Tire
       document = args.shift
       type     = get_type_from_document(document)
 
-      document = MultiJson.decode convert_document_to_json(document)
+      document = MultiJson.load convert_document_to_json(document)
 
       query = Search::Query.new(&block).to_hash if block_given?
 
@@ -252,7 +252,7 @@ module Tire
       payload.update( :query => query ) if query
 
       @response = Configuration.client.get "#{Configuration.url}/#{@name}/#{type}/_percolate", MultiJson.dump(payload)
-      MultiJson.decode(@response.body)['matches']
+      MultiJson.load(@response.body)['matches']
 
     ensure
       curl = %Q|curl -X GET "#{Configuration.url}/#{@name}/#{type}/_percolate?pretty=1" -d '#{payload.to_json}'|

--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -28,11 +28,11 @@ module Tire
 
     def create(options={})
       @options = options
-      @response = Configuration.client.post "#{Configuration.url}/#{@name}", MultiJson.encode(options)
+      @response = Configuration.client.post "#{Configuration.url}/#{@name}", MultiJson.dump(options)
       @response.success? ? @response : false
 
     ensure
-      curl = %Q|curl -X POST "#{Configuration.url}/#{@name}" -d '#{MultiJson.encode(options)}'|
+      curl = %Q|curl -X POST "#{Configuration.url}/#{@name}" -d '#{MultiJson.dump(options)}'|
       logged('CREATE', curl)
     end
 
@@ -192,7 +192,7 @@ module Tire
 
     def open(options={})
       # TODO: Remove the duplication in the execute > rescue > ensure chain
-      @response = Configuration.client.post "#{Configuration.url}/#{@name}/_open", MultiJson.encode(options)
+      @response = Configuration.client.post "#{Configuration.url}/#{@name}/_open", MultiJson.dump(options)
       MultiJson.decode(@response.body)['ok']
 
     ensure
@@ -201,7 +201,7 @@ module Tire
     end
 
     def close(options={})
-      @response = Configuration.client.post "#{Configuration.url}/#{@name}/_close", MultiJson.encode(options)
+      @response = Configuration.client.post "#{Configuration.url}/#{@name}/_close", MultiJson.dump(options)
       MultiJson.decode(@response.body)['ok']
 
     ensure
@@ -223,11 +223,11 @@ module Tire
     def register_percolator_query(name, options={}, &block)
       options[:query] = Search::Query.new(&block).to_hash if block_given?
 
-      @response = Configuration.client.put "#{Configuration.url}/_percolator/#{@name}/#{name}", MultiJson.encode(options)
+      @response = Configuration.client.put "#{Configuration.url}/_percolator/#{@name}/#{name}", MultiJson.dump(options)
       MultiJson.decode(@response.body)['ok']
 
     ensure
-      curl = %Q|curl -X PUT "#{Configuration.url}/_percolator/#{@name}/?pretty=1" -d '#{MultiJson.encode(options)}'|
+      curl = %Q|curl -X PUT "#{Configuration.url}/_percolator/#{@name}/?pretty=1" -d '#{MultiJson.dump(options)}'|
       logged('_percolator', curl)
     end
 
@@ -251,7 +251,7 @@ module Tire
       payload = { :doc => document }
       payload.update( :query => query ) if query
 
-      @response = Configuration.client.get "#{Configuration.url}/#{@name}/#{type}/_percolate", MultiJson.encode(payload)
+      @response = Configuration.client.get "#{Configuration.url}/#{@name}/#{type}/_percolate", MultiJson.dump(payload)
       MultiJson.decode(@response.body)['matches']
 
     ensure
@@ -269,7 +269,7 @@ module Tire
 
         if Configuration.logger.level.to_s == 'debug'
           body = if @response
-            defined?(Yajl) ? Yajl::Encoder.encode(@response.body, :pretty => true) : MultiJson.encode(@response.body)
+            defined?(Yajl) ? Yajl::Encoder.encode(@response.body, :pretty => true) : MultiJson.dump(@response.body)
           else
             error.message rescue ''
           end

--- a/lib/tire/rubyext/hash.rb
+++ b/lib/tire/rubyext/hash.rb
@@ -1,7 +1,7 @@
 class Hash
 
   def to_json(options=nil)
-    MultiJson.encode(self)
+    MultiJson.dump(self)
   end unless respond_to?(:to_json)
 
   alias_method :to_indexed_json, :to_json

--- a/lib/tire/search.rb
+++ b/lib/tire/search.rb
@@ -142,7 +142,7 @@ module Tire
           if Configuration.logger.level.to_s == 'debug'
             # FIXME: Depends on RestClient implementation
             body = if @json
-              defined?(Yajl) ? Yajl::Encoder.encode(@json, :pretty => true) : MultiJson.encode(@json)
+              defined?(Yajl) ? Yajl::Encoder.encode(@json, :pretty => true) : MultiJson.dump(@json)
             else
               @response.body rescue nil
             end

--- a/lib/tire/search.rb
+++ b/lib/tire/search.rb
@@ -96,7 +96,7 @@ module Tire
           STDERR.puts "[REQUEST FAILED] #{self.to_curl}\n"
           raise SearchRequestFailed, @response.to_s
         end
-        @json     = MultiJson.decode(@response.body)
+        @json     = MultiJson.load(@response.body)
         @results  = Results::Collection.new(@json, @options)
         return self
       ensure

--- a/lib/tire/search/scan.rb
+++ b/lib/tire/search/scan.rb
@@ -83,7 +83,7 @@ module Tire
 
       def __perform
         @response  = Configuration.client.get [url, params].join, scroll_id
-        @json      = MultiJson.decode @response.body
+        @json      = MultiJson.load @response.body
         @results   = Results::Collection.new @json, @options
         @total     = @json['hits']['total'].to_i
         @seen     += @results.size

--- a/lib/tire/tasks.rb
+++ b/lib/tire/tasks.rb
@@ -53,7 +53,7 @@ namespace :tire do
 
     unless index.exists?
       mapping = defined?(Yajl) ? Yajl::Encoder.encode(klass.tire.mapping_to_hash, :pretty => true) :
-                                 MultiJson.encode(klass.tire.mapping_to_hash)
+                                 MultiJson.dump(klass.tire.mapping_to_hash)
       puts "[IMPORT] Creating index '#{index.name}' with mapping:", mapping
       index.create :mappings => klass.tire.mapping_to_hash, :settings => klass.tire.settings
     end

--- a/test/unit/index_test.rb
+++ b/test/unit/index_test.rb
@@ -594,7 +594,7 @@ module Tire
         should "register percolator query as a Hash" do
           query = { :query => { :query_string => { :query => 'foo' } } }
           Configuration.client.expects(:put).with do |url, payload|
-                                               payload = MultiJson.decode(payload)
+                                               payload = MultiJson.load(payload)
                                                url == "#{Configuration.url}/_percolator/dummy/my-query" &&
                                                payload['query']['query_string']['query'] == 'foo'
                                end.
@@ -611,7 +611,7 @@ module Tire
 
         should "register percolator query as a block" do
           Configuration.client.expects(:put).with do |url, payload|
-                                               payload = MultiJson.decode(payload)
+                                               payload = MultiJson.load(payload)
                                                url == "#{Configuration.url}/_percolator/dummy/my-query" &&
                                                payload['query']['query_string']['query'] == 'foo'
                                end.
@@ -633,7 +633,7 @@ module Tire
                     :tags  => ['alert'] }
 
           Configuration.client.expects(:put).with do |url, payload|
-                                               payload = MultiJson.decode(payload)
+                                               payload = MultiJson.load(payload)
                                                url == "#{Configuration.url}/_percolator/dummy/my-query" &&
                                                payload['query']['query_string']['query'] == 'foo' &&
                                                payload['tags'] == ['alert']
@@ -657,7 +657,7 @@ module Tire
 
         should "percolate document against all registered queries" do
           Configuration.client.expects(:get).with do |url,payload|
-                                               payload = MultiJson.decode(payload)
+                                               payload = MultiJson.load(payload)
                                                url == "#{Configuration.url}/dummy/document/_percolate" &&
                                                payload['doc']['title'] == 'Test'
                                               end.
@@ -669,7 +669,7 @@ module Tire
 
         should "percolate a typed document against all registered queries" do
           Configuration.client.expects(:get).with do |url,payload|
-                                               payload = MultiJson.decode(payload)
+                                               payload = MultiJson.load(payload)
                                                url == "#{Configuration.url}/dummy/article/_percolate" &&
                                                payload['doc']['title'] == 'Test'
                                               end.
@@ -681,7 +681,7 @@ module Tire
 
         should "percolate document against specific queries" do
           Configuration.client.expects(:get).with do |url,payload|
-                                               payload = MultiJson.decode(payload)
+                                               payload = MultiJson.load(payload)
                                                # p [url, payload]
                                                url == "#{Configuration.url}/dummy/document/_percolate" &&
                                                payload['doc']['title']                   == 'Test' &&

--- a/test/unit/index_test.rb
+++ b/test/unit/index_test.rb
@@ -242,7 +242,7 @@ module Tire
 
           should "store Hash it under its ID property" do
             Configuration.client.expects(:post).with("#{Configuration.url}/dummy/document/123",
-                                                     MultiJson.encode({:id => 123, :title => 'Test'})).
+                                                     MultiJson.dump({:id => 123, :title => 'Test'})).
                                                 returns(mock_response('{"ok":true,"_id":"123"}'))
             @index.store :id => 123, :title => 'Test'
           end

--- a/test/unit/model_persistence_test.rb
+++ b/test/unit/model_persistence_test.rb
@@ -312,7 +312,7 @@ module Tire
           should "save the document with generated ID in the database" do
             Configuration.client.expects(:post).
                                  with do |url, payload|
-                                  doc = MultiJson.decode(payload)
+                                  doc = MultiJson.load(payload)
                                   url == "#{Configuration.url}/persistent_articles/persistent_article/" &&
                                   doc['title'] == 'Test' &&
                                   doc['tags']  == ['one', 'two']
@@ -328,7 +328,7 @@ module Tire
           should "save the document with custom ID in the database" do
             Configuration.client.expects(:post).
                                  with do |url, payload|
-                                   doc = MultiJson.decode(payload)
+                                   doc = MultiJson.load(payload)
                                    url == "#{Configuration.url}/persistent_articles/persistent_article/r2d2" &&
                                    doc['title'] == 'Test' &&
                                    doc['published_on'] == nil
@@ -352,7 +352,7 @@ module Tire
           should "set the id property" do
             Configuration.client.expects(:post).
                                  with do |url, payload|
-                                   doc = MultiJson.decode(payload)
+                                   doc = MultiJson.load(payload)
                                    url == "#{Configuration.url}/persistent_articles/persistent_article/" &&
                                    doc['title'] == 'Test'
                                  end.
@@ -365,7 +365,7 @@ module Tire
           should "not set the id property if already set" do
             Configuration.client.expects(:post).
                                   with do |url, payload|
-                                    doc = MultiJson.decode(payload)
+                                    doc = MultiJson.load(payload)
                                     url == "#{Configuration.url}/persistent_articles/persistent_article/123" &&
                                     doc['title'] == 'Test' &&
                                     doc['published_on'] == nil
@@ -385,7 +385,7 @@ module Tire
 
             Configuration.client.expects(:post).
                                  with do |url, payload|
-                                   doc = MultiJson.decode(payload)
+                                   doc = MultiJson.load(payload)
                                    url == "#{Configuration.url}/persistent_articles/persistent_article/1" &&
                                    doc['title'] == 'Test' &&
                                    doc['published_on'] == nil
@@ -397,7 +397,7 @@ module Tire
 
             Configuration.client.expects(:post).
                                  with do |url, payload|
-                                   doc = MultiJson.decode(payload)
+                                   doc = MultiJson.load(payload)
                                    url == "#{Configuration.url}/persistent_articles/persistent_article/1" &&
                                    doc['title'] == 'Updated'
                                  end.
@@ -428,7 +428,7 @@ module Tire
 
             Configuration.client.expects(:post).
                                  with do |url, payload|
-                                   doc = MultiJson.decode(payload)
+                                   doc = MultiJson.load(payload)
                                    url == "#{Configuration.url}/persistent_articles/persistent_article/456" &&
                                    doc['title'] == 'Test'
                                  end.
@@ -444,7 +444,7 @@ module Tire
           should "delete the document from the database" do
             Configuration.client.expects(:post).
                                  with do |url, payload|
-                                   doc = MultiJson.decode(payload)
+                                   doc = MultiJson.load(payload)
                                    url == "#{Configuration.url}/persistent_articles/persistent_article/123" &&
                                    doc['title'] == 'Test'
                                  end.returns(mock_response('{"ok":true,"_id":"123"}'))

--- a/test/unit/model_search_test.rb
+++ b/test/unit/model_search_test.rb
@@ -528,14 +528,14 @@ module Tire
 
           should "not include the ID property in serialized document (_source)" do
             @model = ActiveModelArticle.new 'id' => 1, 'title' => 'Test'
-            assert_nil MultiJson.decode(@model.to_indexed_json)[:id]
-            assert_nil MultiJson.decode(@model.to_indexed_json)['id']
+            assert_nil MultiJson.load(@model.to_indexed_json)[:id]
+            assert_nil MultiJson.load(@model.to_indexed_json)['id']
           end
 
           should "not include the type property in serialized document (_source)" do
             @model = ActiveModelArticle.new 'type' => 'foo', 'title' => 'Test'
-            assert_nil MultiJson.decode(@model.to_indexed_json)[:type]
-            assert_nil MultiJson.decode(@model.to_indexed_json)['type']
+            assert_nil MultiJson.load(@model.to_indexed_json)[:type]
+            assert_nil MultiJson.load(@model.to_indexed_json)['type']
           end
 
           should "serialize itself with serializable_hash when no mapping is set" do
@@ -621,7 +621,7 @@ module Tire
 
             model    = ::ModelWithMappingProcs.new :one => 1, :two => 1, :three => 1
             hash     = model.serializable_hash
-            document = MultiJson.decode(model.to_indexed_json)
+            document = MultiJson.load(model.to_indexed_json)
 
             assert_equal 1, hash[:one]
             assert_equal 1, hash[:two]
@@ -664,7 +664,7 @@ module Tire
             Tire::Index.any_instance.expects(:store).with do |doc,options|
               # p [doc,options]
               options[:percolate] == true
-            end.returns(MultiJson.decode('{"ok":true,"_id":"test","matches":["alerts"]}'))
+            end.returns(MultiJson.load('{"ok":true,"_id":"test","matches":["alerts"]}'))
 
             @article.update_elasticsearch_index
           end
@@ -673,7 +673,7 @@ module Tire
             Tire::Index.any_instance.expects(:store).with do |doc,options|
               # p [doc,options]
               options[:percolate] == nil
-            end.returns(MultiJson.decode('{"ok":true,"_id":"test"}'))
+            end.returns(MultiJson.load('{"ok":true,"_id":"test"}'))
 
             @article.update_elasticsearch_index
           end
@@ -702,7 +702,7 @@ module Tire
             Tire::Index.any_instance.expects(:store).with do |doc,options|
               # p [doc,options]
               options[:percolate] == true
-            end.returns(MultiJson.decode('{"ok":true,"_id":"test","matches":["alerts"]}'))
+            end.returns(MultiJson.load('{"ok":true,"_id":"test","matches":["alerts"]}'))
 
             percolated = ActiveModelArticleWithPercolation.new :title => 'Percolate me!'
             percolated.update_elasticsearch_index
@@ -720,7 +720,7 @@ module Tire
                                        doc == percolated &&
                                        options[:percolate] == true
                                      end.
-                                     returns(MultiJson.decode('{"ok":true,"_id":"test","matches":["alerts"]}'))
+                                     returns(MultiJson.load('{"ok":true,"_id":"test","matches":["alerts"]}'))
 
             percolated.update_elasticsearch_index
 
@@ -739,7 +739,7 @@ module Tire
                                        doc == percolated &&
                                        options[:percolate] == 'tags:alert'
                                      end.
-                                     returns(MultiJson.decode('{"ok":true,"_id":"test","matches":["alerts"]}'))
+                                     returns(MultiJson.load('{"ok":true,"_id":"test","matches":["alerts"]}'))
 
             percolated.update_elasticsearch_index
 

--- a/test/unit/rubyext_test.rb
+++ b/test/unit/rubyext_test.rb
@@ -36,13 +36,13 @@ module Tire
 
       should "have to_indexed_json method doing the same as to_json" do
         [{}, { 1 => 2 }, { 3 => 4, 5 => 6 }, { nil => [7,8,9] }].each do |h|
-          assert_equal MultiJson.decode(h.to_json), MultiJson.decode(h.to_indexed_json)
+          assert_equal MultiJson.load(h.to_json), MultiJson.load(h.to_indexed_json)
         end
       end
 
       should "properly serialize Time into JSON" do
         json = { :time => Time.mktime(2011, 01, 01, 11, 00).to_json  }.to_json
-        assert_match /"2011-01-01T11:00:00.*"/, MultiJson.decode(json)['time']
+        assert_match /"2011-01-01T11:00:00.*"/, MultiJson.load(json)['time']
       end
 
     end

--- a/test/unit/search_test.rb
+++ b/test/unit/search_test.rb
@@ -219,7 +219,7 @@ module Tire
               by :_score
             end
           end
-          hash = MultiJson.decode( s.to_json )
+          hash = MultiJson.load( s.to_json )
           assert_equal [{'title' => 'desc'}, '_score'], hash['sort']
         end
 
@@ -319,7 +319,7 @@ module Tire
           s = Search::Search.new('index') do
             version true
           end
-          hash = MultiJson.decode( s.to_json )
+          hash = MultiJson.load( s.to_json )
           assert_equal true, hash['version']
         end
 
@@ -332,7 +332,7 @@ module Tire
             size 5
             from 3
           end
-          hash = MultiJson.decode( s.to_json )
+          hash = MultiJson.load( s.to_json )
           assert_equal 5, hash['size']
           assert_equal 3, hash['from']
         end
@@ -363,7 +363,7 @@ module Tire
           s = Search::Search.new('index') do
             fields :title
           end
-          hash = MultiJson.decode( s.to_json )
+          hash = MultiJson.load( s.to_json )
           assert_equal ['title'], hash['fields']
         end
 
@@ -371,7 +371,7 @@ module Tire
           s = Search::Search.new('index') do
             fields [:title, :tags]
           end
-          hash = MultiJson.decode( s.to_json )
+          hash = MultiJson.load( s.to_json )
           assert_equal ['title', 'tags'], hash['fields']
         end
 
@@ -379,7 +379,7 @@ module Tire
           s = Search::Search.new('index') do
             fields :title, :tags
           end
-          hash = MultiJson.decode( s.to_json )
+          hash = MultiJson.load( s.to_json )
           assert_equal ['title', 'tags'], hash['fields']
         end
 
@@ -390,7 +390,7 @@ module Tire
         should "default to false" do
           s = Search::Search.new('index') do
           end
-          hash = MultiJson.decode( s.to_json )
+          hash = MultiJson.load( s.to_json )
           assert_nil hash['explain']
         end
 
@@ -398,7 +398,7 @@ module Tire
           s = Search::Search.new('index') do
             explain true
           end
-          hash = MultiJson.decode( s.to_json )
+          hash = MultiJson.load( s.to_json )
           assert_equal true, hash['explain']
         end
 
@@ -406,7 +406,7 @@ module Tire
           s = Search::Search.new('index') do
             explain false
           end
-          hash = MultiJson.decode( s.to_json )
+          hash = MultiJson.load( s.to_json )
           assert_nil hash['explain']
         end
 
@@ -435,7 +435,7 @@ module Tire
             end
           end
 
-          hash  = MultiJson.decode(s.to_json)
+          hash  = MultiJson.load(s.to_json)
           query = hash['query']['bool']
           # p hash
 

--- a/tire.gemspec
+++ b/tire.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   #
   s.add_dependency "rake"
   s.add_dependency "rest-client", "~> 1.6"
-  s.add_dependency "multi_json",  "~> 1.0"
+  s.add_dependency "multi_json",  "~> 1.3"
   s.add_dependency "activemodel", ">= 3.0"
   s.add_dependency "hashr",       "~> 0.0.19"
   s.add_dependency "rack",        ">= 1.4" if defined?(RUBY_VERSION) && RUBY_VERSION < '1.9'


### PR DESCRIPTION
I just went ahead and made the changes -- I had opened an issue about.

MultiJson 1.3 renamed some methods so I updated the dependency and did a search/replace. Tests passed before and after so looks like it's a simple fix. 

Not sure when/if you want to update the MultiJson dependency since its a big jump but figured other people would be bothered by the log messages as well.
