### PR TITLE
Recent ES doesn't like the sort parameter, so it seems.

### DIFF
--- a/lib/tire/model/search.rb
+++ b/lib/tire/model/search.rb
@@ -72,8 +72,8 @@ module Tire
             options ||= {}
           end
 
-          sort      = Array( options[:order] || options[:sort] )
           options   = default_options.update(options)
+          sort      = Array( options.delete(:order) || options.delete(:sort) )
 
           s = Tire::Search::Search.new(options.delete(:index), options)
           s.size( options[:per_page].to_i ) if options[:per_page]
@@ -298,7 +298,6 @@ module Tire
         Results::Item.send :include, Loader
       end
 
-      
     end
 
   end

--- a/test/unit/model_persistence_test.rb
+++ b/test/unit/model_persistence_test.rb
@@ -24,16 +24,16 @@ module Tire
           setup do
             Model::Search.index_prefix 'prefix'
           end
-          
+
           teardown do
             Model::Search.index_prefix nil
           end
-          
+
           should "have configured prefix in index_name" do
             assert_equal 'prefix_persistent_articles', PersistentArticle.index_name
             assert_equal 'prefix_persistent_articles', PersistentArticle.new(:title => 'Test').index_name
           end
-          
+
         end
 
         should "have document_type" do
@@ -153,6 +153,15 @@ module Tire
           end
         end
 
+      end
+
+      context "Search" do
+        should "not add the sort to the URL path" do
+          Configuration.client.expects(:get).with do |url, payload|
+            assert_equal false, url.include?('sort')
+          end
+          PersistentArticle.search('index', {:sort => "created_at desc"}).perform
+        end
       end
 
       context "Persistent model" do


### PR DESCRIPTION
When the query is provided as hash, the params get concatenated, producing a query like this:

```
curl -X GET "http://localhost:9200/graylog2/message/_search?from=0&page=1&per_page=100&size=100&sort=created_at+desc&pretty=true" -d '{"query":{"query_string":{"query":"*"}},"sort":[{"created_at":"desc"}],"size":100,"from":0}'
```

It produces an error:

Parse Failure [No mapping found for [created_at desc] in order to sort on]

I don't know whether the other parameters should be there, as they're duplicated in the query, but at least they don't make the request invalid.
