### PR TITLE
Enhanced paginate method to sort by id by default

### DIFF
--- a/lib/tire/tasks.rb
+++ b/lib/tire/tasks.rb
@@ -73,7 +73,7 @@ namespace :tire do
       if defined?(Kaminari) && klass.respond_to?(:page)
         klass.instance_eval do
           def paginate(options = {})
-            page(options[:page]).per(options[:per_page]).to_a
+            order("#{klass.table_name}.id").page(options[:page]).per(options[:per_page]).to_a
           end
         end
       end unless klass.respond_to?(:paginate)


### PR DESCRIPTION
This makes sure that there is a default ordering so that 'paginate' method doesn't fetch duplicate records for indexing. This commit fixes #272
