### PR TITLE
Allow slicing of the collection

### DIFF
--- a/lib/tire/results/collection.rb
+++ b/lib/tire/results/collection.rb
@@ -78,9 +78,10 @@ module Tire
       end
       alias :length :size
 
-      def [](index)
-        results[index]
+      def slice(*args)
+        results.slice(*args)
       end
+      alias :[] :slice
 
       def to_ary
         self

--- a/test/unit/results_collection_test.rb
+++ b/test/unit/results_collection_test.rb
@@ -32,6 +32,10 @@ module Tire
         assert_equal 2, Results::Collection.new(@default_response)[1][:id]
       end
 
+      should "allow slicing" do
+        assert_equal [2,3], Results::Collection.new(@default_response)[1, 2].map {|res| res[:id]}
+      end
+
       should "be initialized with parsed json" do
         assert_nothing_raised do
           collection = Results::Collection.new( @default_response )


### PR DESCRIPTION
The [] method can receive an optional second parameter (for slicing).
