### PR TITLE
Adding pagination methods needed for future kaminari release

### DIFF
--- a/lib/tire/results/pagination.rb
+++ b/lib/tire/results/pagination.rb
@@ -48,6 +48,14 @@ module Tire
       alias :num_pages    :total_pages
       alias :offset_value :offset
 
+      def first_page?
+        current_page == 1
+      end
+
+      def last_page?
+        current_page >= total_pages
+      end
+
     end
 
   end


### PR DESCRIPTION
In the master branch of kaminari, they added support for a method link_to_previous_page. This resulted in a lot of their pagination code using the methods included in this pull request.
- https://github.com/amatsuda/kaminari/blob/master/lib/kaminari/helpers/action_view_extension.rb
