### PR TITLE
Add support for update script API on Tire::Index.

### DIFF
--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -275,6 +275,19 @@ module Tire
       logged('_percolate', curl)
     end
 
+    def update(type, id, options)
+      raise ArgumentError, "Please pass a document ID" unless id
+      raise ArgumentError, "Missing script in options hash" unless options[:script]
+
+      type      = Utils.escape(type)
+      url       = "#{self.url}/#{type}/#{id}/_update"
+      @response = Configuration.client.post url, MultiJson.encode(options)
+      MultiJson.decode(@response.body)['ok']
+    ensure
+      curl = %Q|curl -X POST "#{url}"|
+      logged(id, curl)
+    end
+
     def logged(endpoint='/', curl='')
       if Configuration.logger
         error = $!

--- a/test/unit/index_test.rb
+++ b/test/unit/index_test.rb
@@ -745,9 +745,12 @@ module Tire
             payload = MultiJson.decode(payload)
             # p [url, payload]
             url == "#{@index.url}/document/42/_update" &&
-            payload['script'] != nil
+            payload['script'] != nil &&
+            payload['params'] != nil &&
+            payload['params']['x'] == '21' &&
+            payload['params']['y'] == [2,4,6]
           end.returns(mock_response('{"ok":"true","_index":"dummy","_type":"document","_id":"42","_version":"2"}'))
-          assert @index.update('document', '42', {:script => "ctx._source.test = 'youpi';"})
+          assert @index.update('document', '42', {:script => "ctx._source.test = 'youpi';", :params => { :x => '21', :y => [2,4,6] }})
         end
 
         should "raise error when running update without a script or an id" do

--- a/test/unit/index_test.rb
+++ b/test/unit/index_test.rb
@@ -740,6 +740,21 @@ module Tire
           assert_equal ["alerts"], matches
         end
 
+        should "run update script against a given document" do
+          Configuration.client.expects(:post).with do |url,payload|
+            payload = MultiJson.decode(payload)
+            # p [url, payload]
+            url == "#{@index.url}/document/42/_update" &&
+            payload['script'] != nil
+          end.returns(mock_response('{"ok":"true","_index":"dummy","_type":"document","_id":"42","_version":"2"}'))
+          assert @index.update('document', '42', {:script => "ctx._source.test = 'youpi';"})
+        end
+
+        should "raise error when running update without a script or an id" do
+          assert_raise(ArgumentError) { @index.update('lol', "42", {:params => {"foo" => "bar"}}) }
+          assert_raise(ArgumentError) { @index.update('lol', nil, {:script => "ctx._source.test = 'test';"}) }
+        end
+
         context "while storing document" do
 
           should "percolate document against all registered queries" do


### PR DESCRIPTION
Usage:
tags = ['a', 'b', 'c']
Tire.index 'my_index' do
  update 'document_type', 'document_id', {
    :script => "_ctx._source.tags = tags;',
    :params => {:tags => tags}
  }
end
