### PR TITLE
Result decorator

### DIFF
--- a/lib/tire/results/collection.rb
+++ b/lib/tire/results/collection.rb
@@ -16,7 +16,19 @@ module Tire
     def message
       "You have tried to eager load the model instances, " +
       "but Tire cannot find the model class because " +
-      "document has no _type property." 
+      "document has no _type property."
+    end
+  end
+
+  class RecordNotFound < Tire::Exception
+    attr_reader :klass, :ids
+
+    def initialize(klass, ids)
+      @klass, @ids = klass, ids
+    end
+
+    def message
+      "Couldn't find all #{klass.name.pluralize} with IDs (#{ids.join(', ')})."
     end
   end
 
@@ -98,8 +110,10 @@ module Tire
             records["#{type}-#{item.id}"] = item
           end
         end
-          
+
         records
+      rescue ActiveRecord::RecordNotFound
+        raise Tire::RecordNotFound.new(klass, ids)
       end
 
       def parse_results(type, items)

--- a/lib/tire/results/collection.rb
+++ b/lib/tire/results/collection.rb
@@ -1,5 +1,5 @@
 module Tire
-  class Exception < ::Exception; end
+  class Exception < ::StandardError; end
   class UnknownModel < Tire::Exception
     def initialize(type)
       @type = type

--- a/lib/tire/results/item.rb
+++ b/lib/tire/results/item.rb
@@ -24,7 +24,11 @@ module Tire
       # otherwise return +nil+.
       #
       def method_missing(method_name, *arguments)
-        @attributes.has_key?(method_name.to_sym) ? @attributes[method_name.to_sym] : nil
+        if @attributes.has_key?(method_name.to_sym)
+          @attributes[method_name.to_sym]
+        elsif !model.nil?
+          model.send(method_name, *arguments)
+        end
       end
 
       def [](key)
@@ -37,6 +41,10 @@ module Tire
 
       def type
         @attributes[:_type] || @attributes[:type]
+      end
+
+      def model
+        @attributes[:_model]
       end
 
       def persisted?

--- a/test/integration/active_record_searchable_test.rb
+++ b/test/integration/active_record_searchable_test.rb
@@ -95,7 +95,7 @@ module Tire
           results = ActiveRecordArticle.search '"Test 1"', :load => true
       
           assert       results.any?
-          assert_equal ActiveRecordArticle.find(1), results.first
+          assert_equal ActiveRecordArticle.find(1), results.first.model
         end
       
         should "load records on block search" do
@@ -103,13 +103,13 @@ module Tire
             query { string '"Test 1"' }
           end
       
-          assert_equal ActiveRecordArticle.find(1), results.first
+          assert_equal ActiveRecordArticle.find(1), results.first.model
         end
       
         should "load records with options on query search" do
           assert_equal ActiveRecordArticle.find(['1'], :include => 'comments').first,
                        ActiveRecordArticle.search('"Test 1"',
-                                                  :load => { :include => 'comments' }).results.first
+                                                  :load => { :include => 'comments' }).results.first.model
         end
       
         should "return empty collection for nonmatching query" do
@@ -392,8 +392,8 @@ module Tire
            # puts s.results[0].inspect
 
            assert_equal 2, s.results.length
-           assert_instance_of ActiveRecordModelOne, s.results[0]
-           assert_instance_of ActiveRecordModelTwo, s.results[1]
+           assert_instance_of ActiveRecordModelOne, s.results[0].model
+           assert_instance_of ActiveRecordModelTwo, s.results[1].model
          end
 
          should "eagerly load all STI descendant records" do
@@ -403,8 +403,8 @@ module Tire
            end
 
            assert_equal 2, s.results.length
-           assert_instance_of ActiveRecordVideo,  s.results[0]
-           assert_instance_of ActiveRecordPhoto,  s.results[1]
+           assert_instance_of ActiveRecordVideo,  s.results[0].model
+           assert_instance_of ActiveRecordPhoto,  s.results[1].model
          end
       end
 
@@ -434,8 +434,8 @@ module Tire
           results = ActiveRecordNamespace::MyModel.search 'test', :load => true
 
           assert             results.any?, "No results returned: #{results.inspect}"
-          assert_instance_of ActiveRecordNamespace::MyModel, results.first
-          assert_equal       ActiveRecordNamespace::MyModel.find(1), results.first
+          assert_instance_of ActiveRecordNamespace::MyModel, results.first.model
+          assert_equal       ActiveRecordNamespace::MyModel.find(1), results.first.model
         end
 
       end

--- a/test/integration/active_record_searchable_test.rb
+++ b/test/integration/active_record_searchable_test.rb
@@ -121,8 +121,19 @@ module Tire
             assert ! results.any?
           end
         end
+
+        should "wrap loaded document with returned record" do
+          results = ActiveRecordArticle.search :load => true do
+            query { string '"Test 1"' }
+            fields :title
+          end
+
+          assert_equal "Test 1", results.first.title
+          assert_equal 6, results.first.length
+        end
+
       end
-      
+
       should "remove document from index on destroy" do
         a = ActiveRecordArticle.new :title => 'Test remove...'
         a.save!

--- a/test/unit/results_collection_test.rb
+++ b/test/unit/results_collection_test.rb
@@ -247,14 +247,14 @@ module Tire
         end
 
         should "raise error when model class cannot be inferred from _type" do
-          assert_raise(NameError) do
+          assert_raise(Tire::UnknownModel) do
             response = { 'hits' => { 'hits' => [ {'_id' => 1, '_type' => 'hic_sunt_leones'}] } }
             Results::Collection.new(response, :load => true).results
           end
         end
 
         should "raise error when _type is missing" do
-          assert_raise(NoMethodError) do
+          assert_raise(Tire::UnknownType) do
             response = { 'hits' => { 'hits' => [ {'_id' => 1}] } }
             Results::Collection.new(response, :load => true).results
           end

--- a/test/unit/results_item_test.rb
+++ b/test/unit/results_item_test.rb
@@ -122,9 +122,10 @@ module Tire
             extend  ActiveModel::Naming
             include ActiveModel::Conversion
             def self.find(id, options); new; end
+            def foo; :bar; end
           end
 
-          @document = Results::Item.new :id => 1, :_type => 'fake_rails_model', :title => 'Test'
+          @document = Results::Item.new :id => 1, :_type => 'fake_rails_model', :title => 'Test', :_model => FakeRailsModel.new, :_model => FakeRailsModel.new
         end
 
         should "be an instance of model, based on _type" do
@@ -144,6 +145,10 @@ module Tire
           document = Results::Item.new :_type => 'my_model', :title => 'Test', :author => { :name => 'John' }
 
           assert_equal Tire::Results::Item, document.class
+        end
+
+        should "delegate methods to model" do
+          assert_equal :bar, @document.foo
         end
 
       end


### PR DESCRIPTION
Hi,

As I described in #364 I needed a way to merge attributes returned by ElasticSearch with model loaded from database. I needed to get merge them with values returned from `scritp_fields` (see #363). 

So now search results returns array of `Results::Item` whenever you get load models for results or not and passes missing methods first to `attributes` array and than to loaded model.
