### PR TITLE
Mapping generated automatically shouldn't have type property

### DIFF
--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -305,7 +305,7 @@ module Tire
         when document.respond_to?(:document_type)
           document.document_type
         when document.is_a?(Hash)
-          document[:_type] || document['_type'] || document[:type] || document['type']
+          document.delete(:_type) || document.delete('_type') || document.delete(:type) || document.delete('type')
         when document.respond_to?(:_type)
           document._type
         when document.respond_to?(:type) && document.type != document.class

--- a/test/integration/index_mapping_test.rb
+++ b/test/integration/index_mapping_test.rb
@@ -19,6 +19,7 @@ module Tire
 
         assert_equal 'string', index.mapping['article']['properties']['title']['type'],  index.mapping.inspect
         assert_nil             index.mapping['article']['properties']['title']['boost'], index.mapping.inspect
+        assert_nil             index.mapping['article']['properties']['type'], index.mapping.inspect
       end
     end
 


### PR DESCRIPTION
If we use the following:

<pre>
Tire.index 'articles' do
  store :type => 'article',
          :title => 'Three',
          :tags => ['java'],
          :published_on => '2011-01-02'
end
</pre>


then articles index has 'type' as one of the properties in the mapping, for example: 

<pre>
{"analytics":{"study_tracking":{"properties":{"id":{"type":"string"},"member_id":{"type":"string"},"tracked_on":{"type":"date","format":"dateOptionalTime"},"type":{"type":"string"}}}}}
</pre>


This pull request fixes that so that type is not one of the properties in the mapping.
