### PR TITLE
Adds support for classes that don't respond to :new, e.g. Integer

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -11,7 +11,7 @@ communicating by JSON over RESTful HTTP, based on [Lucene](http://lucene.apache.
 
 This Readme provides a brief overview of _Tire's_ features. The more detailed documentation is at <http://karmi.github.com/tire/>.
 
-Both of these documents contain a lot of information. Please set aside some time to read them thoroughly, before you blindly dive into „somehow making it work“. Just skimming through it **won't work** for you. For more information, please refer to the [integration test suite](https://github.com/karmi/tire/tree/master/test/integration)
+Both of these documents contain a lot of information. Please set aside some time to read them thoroughly, before you blindly dive into "somehow making it work". Just skimming through it **won't work** for you. For more information, please refer to the [integration test suite](https://github.com/karmi/tire/tree/master/test/integration)
 and [issues](https://github.com/karmi/tire/issues).
 
 Installation

--- a/lib/tire/model/persistence/attributes.rb
+++ b/lib/tire/model/persistence/attributes.rb
@@ -120,8 +120,10 @@ module Tire
               when klass = self.class.property_types[name.to_sym]
                 if klass.is_a?(Array) && value.is_a?(Array)
                   value.map { |v| klass.first.new(v) }
-                else
+                elsif klass.respond_to? :new
                   klass.new(value)
+                else
+                  method(klass.name).call(value)
                 end
 
               when value.is_a?(Hash)

--- a/lib/tire/model/persistence/attributes.rb
+++ b/lib/tire/model/persistence/attributes.rb
@@ -119,7 +119,7 @@ module Tire
 
               when klass = self.class.property_types[name.to_sym]
                 if klass.is_a?(Array) && value.is_a?(Array)
-                  value.map { |v| klass.first.new(v) }
+                  value.map { |v| klass.first.respond_to?(:new) ? klass.first.new(v) : method(klass.first.name).call(v)}
                 elsif klass.respond_to? :new
                   klass.new(value)
                 else

--- a/lib/tire/model/persistence/attributes.rb
+++ b/lib/tire/model/persistence/attributes.rb
@@ -119,7 +119,7 @@ module Tire
 
               when klass = self.class.property_types[name.to_sym]
                 if klass.is_a?(Array) && value.is_a?(Array)
-                  value.map { |v| klass.first.respond_to?(:new) ? klass.first.new(v) : method(klass.first.name).call(v)}
+                  klass.first.respond_to?(:new) ? value.map { |v| klass.first.new(v) } : value.map { |v| method(klass.first.name).call(v) }
                 elsif klass.respond_to? :new
                   klass.new(value)
                 else

--- a/test/models/persistent_article_with_casting.rb
+++ b/test/models/persistent_article_with_casting.rb
@@ -26,3 +26,11 @@ class PersistentArticleWithCastedCollection
   property :title
   property :comments, :class => [Comment]
 end
+
+class PersistentArticleWithCastedNumber
+  include Tire::Model::Persistence
+
+  property :title
+  property :count, :class => Integer
+  property :stats
+end

--- a/test/models/persistent_article_with_casting.rb
+++ b/test/models/persistent_article_with_casting.rb
@@ -31,6 +31,7 @@ class PersistentArticleWithCastedNumber
   include Tire::Model::Persistence
 
   property :title
-  property :count, :class => Integer
+  property :price, :class => Float
+  property :sizes, :class => [Integer]
   property :stats
 end

--- a/test/unit/model_persistence_test.rb
+++ b/test/unit/model_persistence_test.rb
@@ -24,16 +24,16 @@ module Tire
           setup do
             Model::Search.index_prefix 'prefix'
           end
-          
+
           teardown do
             Model::Search.index_prefix nil
           end
-          
+
           should "have configured prefix in index_name" do
             assert_equal 'prefix_persistent_articles', PersistentArticle.index_name
             assert_equal 'prefix_persistent_articles', PersistentArticle.new(:title => 'Test').index_name
           end
-          
+
         end
 
         should "have document_type" do
@@ -306,9 +306,11 @@ module Tire
           end
 
           should "cast to classes that don't respond to :new e.g. Integer" do
-            article = PersistentArticleWithCastedNumber.new :title => 'Test', :count => 4
-            assert_equal 4, article.count
-            assert_instance_of Fixnum, article.count
+            article = PersistentArticleWithCastedNumber.new :title => 'Test', :price => 4.1, :sizes => [6,8,10,12]
+            assert_equal 4, article.price.floor
+            assert_instance_of Float, article.price
+            assert_equal [6,8,10,12], article.sizes
+            assert_instance_of Fixnum, article.sizes.first
           end
 
         end

--- a/test/unit/model_persistence_test.rb
+++ b/test/unit/model_persistence_test.rb
@@ -305,6 +305,12 @@ module Tire
             assert_equal 'A', article.stats.meta.tags
           end
 
+          should "cast to classes that don't respond to :new e.g. Integer" do
+            article = PersistentArticleWithCastedNumber.new :title => 'Test', :count => 4
+            assert_equal 4, article.count
+            assert_instance_of Fixnum, article.count
+          end
+
         end
 
         context "when initializing" do


### PR DESCRIPTION
For example, with the below class, the Integer conversion now works. Before it would try to call `Integer.new('4')`, now it tries to call `Integer('4')`.

``` ruby
class PersistentArticleWithCastedNumber
  include Tire::Model::Persistence

  property :title
  property :count, :class => Integer
  property :stats
end
```
