### PR TITLE
Made changes for easier ruby 1.8 integration

### DIFF
--- a/lib/tire/rubyext/ruby_1_8.rb
+++ b/lib/tire/rubyext/ruby_1_8.rb
@@ -1,7 +1,67 @@
 require 'rubygems'
 
-# Require URI escape/unescape compatibility layer from Rack
-#
-# See <http://www.ruby-doc.org/stdlib-1.9.3/libdoc/uri/rdoc/URI.html#method-c-encode_www_form_component>
-#
-require 'rack/backports/uri/common_18'
+# Use additional URI. This is different from the karmi/tire in that we are not requiring specific RACK versions.
+# This allows for compatibility with older versions of Rails.
+
+module URI
+  TBLENCWWWCOMP_ = {} # :nodoc:
+  TBLDECWWWCOMP_ = {} # :nodoc:
+
+  # Encode given +s+ to URL-encoded form data.
+  #
+  # This method doesn't convert *, -, ., 0-9, A-Z, _, a-z, but does convert SP
+  # (ASCII space) to + and converts others to %XX.
+  #
+  # This is an implementation of
+  # http://www.w3.org/TR/html5/forms.html#url-encoded-form-data
+  #
+  # See URI.decode_www_form_component, URI.encode_www_form
+  def self.encode_www_form_component(s)
+    str = s.to_s
+    if RUBY_VERSION < "1.9" && $KCODE =~ /u/i
+      str.gsub(/([^ a-zA-Z0-9_.-]+)/) do
+        '%' + $1.unpack('H2' * Rack::Utils.bytesize($1)).join('%').upcase
+      end.tr(' ', '+')
+    else
+      if TBLENCWWWCOMP_.empty?
+        tbl = {}
+        256.times do |i|
+          tbl[i.chr] = '%%%02X' % i
+        end
+        tbl[' '] = '+'
+        begin
+          TBLENCWWWCOMP_.replace(tbl)
+          TBLENCWWWCOMP_.freeze
+        rescue
+        end
+      end
+      str.gsub(/[^*\-.0-9A-Z_a-z]/) {|m| TBLENCWWWCOMP_[m]}
+    end
+  end
+
+  # Decode given +str+ of URL-encoded form data.
+  #
+  # This decods + to SP.
+  #
+  # See URI.encode_www_form_component, URI.decode_www_form
+  def self.decode_www_form_component(str, enc=nil)
+    if TBLDECWWWCOMP_.empty?
+      tbl = {}
+      256.times do |i|
+        h, l = i>>4, i&15
+        tbl['%%%X%X' % [h, l]] = i.chr
+        tbl['%%%x%X' % [h, l]] = i.chr
+        tbl['%%%X%x' % [h, l]] = i.chr
+        tbl['%%%x%x' % [h, l]] = i.chr
+      end
+      tbl['+'] = ' '
+      begin
+        TBLDECWWWCOMP_.replace(tbl)
+        TBLDECWWWCOMP_.freeze
+      rescue
+      end
+    end
+    raise ArgumentError, "invalid %-encoding (#{str})" unless /\A(?:%[0-9a-fA-F]{2}|[^%])*\z/ =~ str
+    str.gsub(/\+|%[0-9a-fA-F]{2}/) {|m| TBLDECWWWCOMP_[m]}
+  end
+end

--- a/tire.gemspec
+++ b/tire.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_dependency "multi_json",  "~> 1.0"
   s.add_dependency "activemodel", ">= 3.0"
   s.add_dependency "hashr",       "~> 0.0.19"
-  s.add_dependency "rack",        ">= 1.4" if defined?(RUBY_VERSION) && RUBY_VERSION < '1.9'
+  s.add_dependency "rack",        ">= 1.2" if defined?(RUBY_VERSION) && RUBY_VERSION < '1.9' # No longer must be >= 1.4
 
   # = Development dependencies
   #


### PR DESCRIPTION
Hi, I needed to make these changes for a project I'm working on (a rails 3.0.3 project that had some strong gem dependencies that didn't allow me to update rack to version >= 1.4). And the entire project was created for ruby 1.8.7, and upgrading to 1.9+ is not an option at this point--though it is planned for the future when time permits. 

I feel that this situation may be somewhat common, and therefore these changes allow Tire to work properly without as many dependency headaches. It's up to you if you want to include these changes, but by making these changes it certainly made my life easier!
