### PR TITLE
Use standard Logger interface in Tire::Logger

### DIFF
--- a/lib/tire/logger.rb
+++ b/lib/tire/logger.rb
@@ -1,15 +1,13 @@
 module Tire
   class Logger
 
-    def initialize(device, options={})
-      @device = if device.respond_to?(:write)
-        device
+    def initialize(logger, options={})
+      @logger = if logger.is_a?(::Logger)
+        logger
       else
-        File.open(device, 'a')
+        ::Logger.new(logger)
       end
-      @device.sync = true if @device.respond_to?(:sync)
       @options = options
-      # at_exit { @device.close unless @device.closed? } if @device.respond_to?(:closed?) && @device.respond_to?(:close)
     end
 
     def level
@@ -17,7 +15,7 @@ module Tire
     end
 
     def write(message)
-      @device.write message
+      @logger.send(level.to_sym, message)
     end
 
     def log_request(endpoint, params=nil, curl='')


### PR DESCRIPTION
Hi,

when developing in a Virtualbox shared folder, the `Tire::Logger` sometimes fails to write to the logfile with `Errno::EPROTO` (in #write).

I made a quick patch that replaces the device with a ruby Logger instance, which works fine on shared folders.

Regards

1st8
