### PR TITLE
dis_max support in DSL

### DIFF
--- a/lib/tire/search/query.rb
+++ b/lib/tire/search/query.rb
@@ -68,6 +68,13 @@ module Tire
         @value
       end
 
+      def dis_max(&block)
+        @dis_max = DisMaxQuery.new
+        block.arity < 1 ? @dis_max.instance_eval(&block) : block.call(@dis_max) if block_given?
+        @value[:dis_max] = @dis_max.to_hash
+        @value
+      end
+
       def all
         @value = { :match_all => {} }
         @value
@@ -148,6 +155,27 @@ module Tire
 
       def to_hash
         @value
+      end
+
+      def to_json
+        to_hash.to_json
+      end
+    end
+
+    class DisMaxQuery
+      def initialize(options={}, &block)
+        @options = options
+        @value = {}
+        block.arity < 1 ? self.instance_eval(&block) : block.call(self) if block_given?
+      end
+
+      def query(&block)
+        (@value[:queries] ||= []) << Query.new(&block).to_hash
+        @value
+      end
+
+      def to_hash
+        @value.update(@options)
       end
 
       def to_json

--- a/test/unit/search_test.rb
+++ b/test/unit/search_test.rb
@@ -458,6 +458,29 @@ module Tire
 
       end
 
+      context "dis_max queries" do
+
+        should "wrap other queries" do
+          s = Search::Search.new('index') do
+            query do
+              dis_max do
+                query { string 'foo' }
+                query { terms :tags, ['baz'] }
+              end
+            end
+          end
+
+          hash  = MultiJson.decode(s.to_json)
+          query = hash['query']['dis_max']
+
+          assert_equal 2, query['queries'].size
+
+          assert_equal( { 'query_string' => { 'query' => 'foo' } }, query['queries'].first)
+          assert_equal( { 'terms' => { 'tags' => ['baz'] } }, query['queries'].last)
+        end
+
+      end
+
     end
 
     context "script field" do


### PR DESCRIPTION
This change implements support for the `dis_max` query type.  So you can do, for example:

``` ruby
Search::Search.new('index') do
  query do
    dis_max do
      query { string 'foo' }
      query { terms :tags, ['baz'] }
    end
  end
end
```
