### PR TITLE
Fix for Tire::Alias interface for aliases including routing values

### DIFF
--- a/lib/tire/alias.rb
+++ b/lib/tire/alias.rb
@@ -77,7 +77,7 @@ module Tire
       @attributes = { :indices => IndexCollection.new([]) }
 
       attributes.each_pair do |key, value|
-        if key.to_s =~ /index|indices/
+        if ['index','indices'].include? key.to_s
           @attributes[:indices] = IndexCollection.new(value)
         else
           @attributes[key.to_sym] = value

--- a/test/unit/index_alias_test.rb
+++ b/test/unit/index_alias_test.rb
@@ -83,7 +83,7 @@ module Tire
       context "updating" do
         setup do
           Configuration.client.expects(:get).
-                               returns( mock_response(                               %q|{"index_A":{"aliases":{}},"index_B":{"aliases":{"alias_john":{"filter":{"term":{"user":"john"}}},"alias_martha":{"filter":{"term":{"user":"martha"}}}}},"mongoid_articles":{"aliases":{}},"index_C":{"aliases":{"alias_martha":{"filter":{"term":{"user":"martha"}}}}}}|), 200 ).at_least_once
+                               returns( mock_response(                               %q|{"index_A":{"aliases":{}},"index_B":{"aliases":{"alias_john":{"filter":{"term":{"user":"john"}}},"alias_martha":{"filter":{"term":{"user":"martha"}}}}},"mongoid_articles":{"aliases":{}},"index_C":{"aliases":{"alias_martha":{"filter":{"term":{"user":"martha"}},"index_routing":"1","search_routing":"2"}}}}|), 200 ).at_least_once
         end
 
         should "add indices to alias" do
@@ -94,7 +94,7 @@ module Tire
               a['add']['alias'] == 'alias_martha'
               end
           end.returns(mock_response('{}'), 200)
-          
+
           a = Alias.find('alias_martha')
           a.indices.push 'index_A'
           a.save
@@ -109,7 +109,7 @@ module Tire
                 a['remove']['alias'] == 'alias_martha'
               end
           end.returns(mock_response('{}'), 200)
-          
+
           a = Alias.find('alias_martha')
           a.indices.delete 'index_A'
           a.save
@@ -120,7 +120,7 @@ module Tire
             # puts json
             MultiJson.decode(json)['actions'].all? { |a| a['add']['routing'] == 'martha' }
           end.returns(mock_response('{}'), 200)
-          
+
           a = Alias.find('alias_martha')
           a.routing('martha')
           a.save
@@ -155,7 +155,7 @@ module Tire
         setup do
           Configuration.client.expects(:get).with do |url, json|
               url  == "#{Configuration.url}/_aliases"
-            end.returns( mock_response(                               %q|{"index_A":{"aliases":{}},"index_B":{"aliases":{"alias_john":{"filter":{"term":{"user":"john"}}},"alias_martha":{"filter":{"term":{"user":"martha"}}}}},"index_C":{"aliases":{"alias_martha":{"filter":{"term":{"user":"martha"}}}}}}|), 200 )
+            end.returns( mock_response(                               %q|{"index_A":{"aliases":{}},"index_B":{"aliases":{"alias_john":{"filter":{"term":{"user":"john"}}},"alias_martha":{"filter":{"term":{"user":"martha"}}}}},"index_C":{"aliases":{"alias_martha":{"filter":{"term":{"user":"martha"}},"index_routing":"1","search_routing":"2"}}}}|), 200 )
         end
 
         should "find all aliases" do
@@ -169,7 +169,7 @@ module Tire
           Configuration.client.unstub(:get)
           Configuration.client.expects(:get).with do |url, json|
               url  == "#{Configuration.url}/index_C/_aliases"
-            end.returns( mock_response(                               %q|{"index_C":{"aliases":{"alias_martha":{"filter":{"term":{"user":"martha"}}}}}}|), 200 )
+            end.returns( mock_response(                               %q|{"index_C":{"aliases":{"alias_martha":{"filter":{"term":{"user":"martha"}},"index_routing":"1","search_routing":"2"}}}}|), 200 )
 
           aliases = Alias.all('index_C')
           # p aliases


### PR DESCRIPTION
This is a small change to the way Tire picks out the "indices" attribute passed to the Alias initializer. The original regex match only works if an existing Alias doesn't have a routing value associated with it. If a routing value is set, ElasticSearch returns a key called "index_routing", which can overwrite the "indices" or "index" value if it comes later in the hash iteration, since that key also matches the regex "/index|indices/". 

This problem appeared to us when using Tire::Alias.find() to find the indices associated with a particular alias. We were finding the alias correctly, but the list of indices returned with the Alias object was always incorrect — it was set to the value returned as "index_routing" instead.

Let me know if you need more details for reproduction.
