### PR TITLE
Add ability to pass arguments to query { all }

### DIFF
--- a/lib/tire/search/query.rb
+++ b/lib/tire/search/query.rb
@@ -75,8 +75,8 @@ module Tire
         @value
       end
 
-      def all
-        @value = { :match_all => {} }
+      def all(match_all_args = {})
+        @value = { :match_all => match_all_args }
         @value
       end
 

--- a/test/unit/search_query_test.rb
+++ b/test/unit/search_query_test.rb
@@ -105,6 +105,10 @@ module Tire::Search
       should "search for all documents" do
         assert_equal( { :match_all => { } }, Query.new.all )
       end
+
+      should "pass arguments through to match_all" do
+        assert_equal( { :match_all => {'norms_field' => 'name'} }, Query.new.all('norms_field' => 'name') )
+      end
     end
 
     context "IDs query" do


### PR DESCRIPTION
In elasticsearch, match_all takes arguments that affect the boosting.
For example, if you want to perform empty queries that still respect
document boost, you need to pass {'norms_field' => '[field]'} to match_all.

This adds an optional hash argument to Search::Query#all that is a
pass-through to elasticsearch' match_all.
