### PR TITLE
Support complex hash options for the `term` query:

### DIFF
--- a/lib/tire/search/query.rb
+++ b/lib/tire/search/query.rb
@@ -8,7 +8,11 @@ module Tire
       end
 
       def term(field, value, options={})
-        query = { field => { :term => value }.update(options) }
+        query = if value.is_a?(Hash)
+          { field => value }
+        else
+          { field => { :term => value }.update(options) }
+        end
         @value = { :term => query }
       end
 

--- a/test/unit/search_query_test.rb
+++ b/test/unit/search_query_test.rb
@@ -29,6 +29,10 @@ module Tire::Search
       should "allow search for single term passing an options hash" do
         assert_equal( { :term => { :foo => { :term => 'bar', :boost => 2.0 } } }, Query.new.term(:foo, 'bar', :boost => 2.0) )
       end
+
+      should "allow complex term queries" do
+        assert_equal( { :term => { :foo => { :field => 'bar', :boost => 2.0 } } }, Query.new.term(:foo, {field: 'bar', :boost => 2.0}) )
+      end
     end
 
     context "Terms query" do


### PR DESCRIPTION
Example Query:

``` ruby
Tire.search(@@index_name) do
  query do
    boolean do
      should do
        term :level, { value: "high",   boost: 3}
      end
    end
  end
end
```

More information about this can be found in https://github.com/karmi/tire/issues/422 where there is more example code.

The resulting JSON output of the above is:

``` json
{
  "query": {
    "bool": {
      "should": [{
        "term": {
          "level": {
            "value": "high",
            "boost": 3
          }
        }
      }]
    }
  }
}
```

This does not break any other behaviour.
