### PR TITLE
Allow classes to be passed instead of index name strings

### DIFF
--- a/lib/tire/search.rb
+++ b/lib/tire/search.rb
@@ -13,6 +13,7 @@ module Tire
         else
           @indices = Array(indices)
         end
+        @indices = @indices.map { |i| i.respond_to?(:index_name) ? i.index_name : i }
         @types   = Array(options.delete(:type)).map { |type| Utils.escape(type) }
         @options = options
 

--- a/test/unit/search_test.rb
+++ b/test/unit/search_test.rb
@@ -17,6 +17,16 @@ module Tire
         assert_match %r|/index1,index2/_search|, s.url
       end
 
+      should "be initialized with single index from class" do
+        s = Search::Search.new(ActiveModelArticle) { query { string 'foo' } }
+        assert_match %r|/active_model_articles/_search|, s.url
+      end
+
+      should "be initialized with multiple indices mixed from string and classes" do
+        s = Search::Search.new([ 'index', ActiveModelArticle]) { query { string 'foo' } }
+        assert_match %r|/index,active_model_articles/_search|, s.url
+      end
+
       should "be initialized with multiple indices with options" do
         indices = {'index1' => {:boost => 1},'index2' => {:boost => 2}}
         s = Search::Search.new(indices) { query { string 'foo' } }


### PR DESCRIPTION
Added functionality to allow classes responding to an :index_name method to be passed into search.  Very useful when defining global or individual index names or prefixes.
