### PR TITLE
Added support for partial_fields

### DIFF
--- a/lib/tire/search.rb
+++ b/lib/tire/search.rb
@@ -116,6 +116,14 @@ module Tire
         self
       end
 
+      def partial_fields(name, include_fields, exclude_fields =[])
+        @partial_fields ||= {} 
+        @partial_fields[name] = {}
+        @partial_fields[name]['include'] = include_fields unless include_fields.empty?
+        @partial_fields[name]['exclude'] = exclude_fields unless exclude_fields.empty?
+        self
+      end
+
       def perform
         @response = Configuration.client.get(self.url + self.params, self.to_json)
         if @response.failure?
@@ -149,6 +157,7 @@ module Tire
           request.update( { :script_fields => @script_fields } ) if @script_fields
           request.update( { :version => @version } )         if @version
           request.update( { :explain => @explain } )         if @explain
+          request.update( { :partial_fields => @partial_fields} ) if @partial_fields
           request
         end
       end


### PR DESCRIPTION
I added a simple method to support partial_fields. partial_fields allow the returning of a subset of the record in elastic search. For example if your structured data looks like this:

```
:data => {
   :name => {
      :first => "James",
      :last => "Bond"
   }
} 

```

This could be queried to get the partial records as such:

```
s = Tire.search('articles') do
  query do
      string "James"
  end
  partial_fields "header", ['data.name.last.*']
end

```

The record returned will contain a field called 'header' with the hash

```
:data => {
   :name => {
      :last => "Bond"
   }
} 
```

The function also supports exclude, but this seem to have no effect on the returned data. It is passed in the query as documented in the elastic search documentation.There may be multiple fields in each the include list and exclude list.

http://www.elasticsearch.org/guide/reference/api/search/fields.html
