### PR TITLE
Acceptig symbol as :as parameters when indexing and documents and adding documentation on how to use lambda's on it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ examples/*.html
 .rvmrc
 .rbenv-version
 tags
+Procfile

--- a/README.markdown
+++ b/README.markdown
@@ -440,7 +440,37 @@ You can define different [_analyzers_](http://www.elasticsearch.org/guide/refere
 or any other configuration for _elasticsearch_.
 
 You're not limited to 1:1 mapping between your model properties and the serialized document. With the `:as` option,
-you can pass a string or a _Proc_ object which is evaluated in the instance context (see the `content_size` property).
+you can pass a symbol, string, _lambda_ or a _Proc_ object to generate the value. The evaluation is done as follows:
+
+If `String` the text given is evaluated at the current instance (using `instance_eval`), look at the `content.size` property above.
+
+If `Symbol` a method with the same name as the symbol is called at the current instance, as in:
+
+```ruby
+    mapping do 
+     indexes :id, :as => :some_other_id
+    end
+    
+    def some_other_id
+      self.component.id
+    end    
+```
+
+If `Proc`, the proc is evaluated against the current instance (using `instance_eval`), as in:
+
+```ruby
+    mapping do 
+     indexes :author_name, :as => proc { author.name }
+    end
+```
+
+If `lambda`, the lambda is evaluated passing the current object as a parameter:
+
+```ruby
+    mapping do 
+     indexes :author_name, :as => lambda { |article| article.author.name }
+    end
+```
 
 Chances are, you want to declare also a custom _settings_ for the index, such as set the number of shards,
 replicas, or create elaborate analyzer chains, such as the hipster's choice: [_ngrams_](https://gist.github.com/1160430).

--- a/README.markdown
+++ b/README.markdown
@@ -447,13 +447,13 @@ If `String` the text given is evaluated at the current instance (using `instance
 If `Symbol` a method with the same name as the symbol is called at the current instance, as in:
 
 ```ruby
-    mapping do 
-     indexes :id, :as => :some_other_id
+    mapping do
+      indexes :category, :as => :category_name
     end
-    
-    def some_other_id
-      self.component.id
-    end    
+
+    def category_name
+      self.category.name
+    end
 ```
 
 If `Proc`, the proc is evaluated against the current instance (using `instance_eval`), as in:

--- a/lib/tire.rb
+++ b/lib/tire.rb
@@ -11,6 +11,7 @@ require 'active_support/core_ext/hash/except.rb'
 # Ruby 1.8 compatibility
 require 'tire/rubyext/ruby_1_8' if defined?(RUBY_VERSION) && RUBY_VERSION < '1.9'
 
+require 'tire/errors'
 require 'tire/rubyext/hash'
 require 'tire/rubyext/symbol'
 require 'tire/utils'

--- a/lib/tire/errors.rb
+++ b/lib/tire/errors.rb
@@ -1,0 +1,9 @@
+module Tire
+  class InvalidAsOptionException < Exception
+
+    def initialize( value )
+      super("Unknown type for :as field, accepted types are `Symbol`, `String`, `lambda`s and `Proc`s - #{value.class.name} - #{value.inspect}")
+    end
+
+  end
+end

--- a/lib/tire/invalid_as_option_exception.rb
+++ b/lib/tire/invalid_as_option_exception.rb
@@ -1,0 +1,9 @@
+module Tire
+  class InvalidAsOptionException < Exception
+
+    def initialize( value )
+      super("Unknown type for :as field, accepted types are `Symbol`, `String` and `Proc`s - #{value.class.name} - #{value.inspect}")
+    end
+
+  end
+end

--- a/lib/tire/invalid_as_option_exception.rb
+++ b/lib/tire/invalid_as_option_exception.rb
@@ -1,9 +1,0 @@
-module Tire
-  class InvalidAsOptionException < Exception
-
-    def initialize( value )
-      super("Unknown type for :as field, accepted types are `Symbol`, `String` and `Proc`s - #{value.class.name} - #{value.inspect}")
-    end
-
-  end
-end

--- a/lib/tire/model/indexing.rb
+++ b/lib/tire/model/indexing.rb
@@ -78,6 +78,9 @@ module Tire
         # * Use the `:as` option to dynamically define the serialized property value, eg:
         #
         #       :as => 'content.split(/\W/).length'
+        #       :as => :author_name                        # calls the author_name method
+        #       :as => proc { category.name }              # evaluates the proc at the current instance
+        #       :as => lambda { |item| item.product.name } # evaluates the lambda passing the current instance as a parameter
         #
         # Please refer to the
         # [_mapping_ documentation](http://www.elasticsearch.org/guide/reference/mapping/index.html)
@@ -85,6 +88,15 @@ module Tire
         #
         def indexes(name, options = {}, &block)
           mapping[name] = options
+
+          unless options[:as].nil?
+            case options[:as]
+              when String, Symbol, Proc
+                true # ok, don't do anything
+              else
+                raise Tire::InvalidAsOptionException.new( options[:as] )
+            end
+          end
 
           if block_given?
             mapping[name][:type]       ||= 'object'

--- a/lib/tire/model/search.rb
+++ b/lib/tire/model/search.rb
@@ -1,5 +1,3 @@
-require 'tire/invalid_as_option_exception'
-
 module Tire
   module Model
 

--- a/test/integration/active_record_searchable_test.rb
+++ b/test/integration/active_record_searchable_test.rb
@@ -361,14 +361,14 @@ module Tire
              create_table(:active_record_model_two) { |t| t.string :title, :timestamp }
            end
 
-           ActiveRecordModelOne.create :title => 'Title One', timestamp: Time.now.to_i
-           ActiveRecordModelTwo.create :title => 'Title Two', timestamp: Time.now.to_i
+           ActiveRecordModelOne.create :title => 'Title One', :timestamp => Time.now.to_i
+           ActiveRecordModelTwo.create :title => 'Title Two', :timestamp => Time.now.to_i
            ActiveRecordModelOne.tire.index.refresh
            ActiveRecordModelTwo.tire.index.refresh
 
 
-           ActiveRecordVideo.create! :title => 'Title One', timestamp: Time.now.to_i
-           ActiveRecordPhoto.create! :title => 'Title Two', timestamp: Time.now.to_i
+           ActiveRecordVideo.create! :title => 'Title One', :timestamp => Time.now.to_i
+           ActiveRecordPhoto.create! :title => 'Title Two', :timestamp => Time.now.to_i
            ActiveRecordAsset.tire.index.refresh
          end
 

--- a/test/integration/active_record_with_custom_fields_test.rb
+++ b/test/integration/active_record_with_custom_fields_test.rb
@@ -1,0 +1,71 @@
+require_relative '../test_helper'
+require_relative '../models/active_record_models'
+
+module Tire
+
+  class ActiveRecordWithCustomFieldsTest < Test::Unit::TestCase
+    include Test::Integration
+
+    def setup
+      super
+      ActiveRecord::Base.establish_connection( :adapter => 'sqlite3', :database => ":memory:" )
+
+      ActiveRecord::Schema.define(:version => 1) do
+
+        create_table :active_record_news_stories do |t|
+          t.string  :title, :null => false
+          t.text    :content, :null => false
+          t.integer :category_id, :null => false
+          t.integer :author_id, :null => false
+        end
+
+        create_table :active_record_categories do |t|
+          t.string :name, :null => false
+        end
+
+        create_table :active_record_authors do |t|
+          t.string :name, :null => false
+        end
+
+      end
+    end
+
+    context "Testing :as properties" do
+
+      def clean
+        [ ActiveRecordNewsStory, ActiveRecordCategory, ActiveRecordAuthor ].each(&:destroy_all)
+        Tire.index('active_record_news_stories').delete
+      end
+
+      setup do
+        clean
+
+        @category = ActiveRecordCategory.create!(:name => 'Science Fiction')
+        @author   = ActiveRecordAuthor.create!(:name => 'Phillip K. Dick')
+      end
+
+      teardown do
+        clean
+      end
+
+      should 'correcty add the :as fields defined in the model' do
+        news_story = ActiveRecordNewsStory.new(
+          :title => 'New book',
+          :content => 'A new book has been published on sci-fi',
+          :author_id => @author.id,
+          :category_id => @category.id)
+
+        data_hash = news_story.to_indexed_hash
+
+        assert_equal @category.name, data_hash[:category_name]
+        assert_equal @author.name, data_hash[:author_name]
+        assert_equal @category.name, data_hash[:block_category_name]
+        assert_equal @author.name, data_hash[:string_author_name]
+        assert_equal @category.name, data_hash[:lambda_category_name]
+      end
+
+    end
+
+  end
+
+end

--- a/test/models/active_record_models.rb
+++ b/test/models/active_record_models.rb
@@ -108,6 +108,52 @@ class ActiveRecordPhoto < ActiveRecordAsset
   index_name 'active_record_assets'
 end
 
+class ActiveRecordNewsStory < ActiveRecord::Base
+  include Tire::Model::Search
+  include Tire::Model::Callbacks
+
+  index_name 'active_record_news_stories'
+
+  tire do
+    mapping do
+      indexes :id, :index => :not_analysed
+      indexes :title
+      indexes :content
+      indexes :author_name, :as => :author_name
+      indexes :category_name, :as => :category_name
+      indexes :block_category_name, :as => proc { category.name }
+      indexes :string_author_name,  :as => 'author.name'
+      indexes :lambda_category_name, :as => lambda {|news_story| news_story.category_name }
+    end
+  end
+
+  belongs_to :category, :class_name => 'ActiveRecordCategory'
+  belongs_to :author, :class_name => 'ActiveRecordAuthor'
+
+  attr_accessible :category_id, :author_id, :title, :content
+
+  def author_name
+    self.author.name
+  end
+
+  def category_name
+    self.category.name
+  end
+
+end
+
+class ActiveRecordCategory < ActiveRecord::Base
+  has_many :news_stories, :class_name => 'ActiveRecordNewsStory'
+
+  attr_accessible :name
+end
+
+class ActiveRecordAuthor < ActiveRecord::Base
+  has_many :news_stories, :class_name => 'ActiveRecordNewsStory'
+
+  attr_accessible :name
+end
+
 # Namespaced ActiveRecord models
 
 module ActiveRecordNamespace

--- a/test/models/active_record_models.rb
+++ b/test/models/active_record_models.rb
@@ -116,7 +116,7 @@ class ActiveRecordNewsStory < ActiveRecord::Base
 
   tire do
     mapping do
-      indexes :id, :index => :not_analysed
+      indexes :id
       indexes :title
       indexes :content
       indexes :author_name, :as => :author_name

--- a/test/unit/model_search_test.rb
+++ b/test/unit/model_search_test.rb
@@ -907,6 +907,28 @@ module Tire
 
       end
 
+      context 'trying to index with invalid :as option' do
+
+        should 'raise a Tire::InvalidAsOptionException if :as is of an invalid type' do
+
+          assert_raise ::Tire::InvalidAsOptionException do
+
+            class SomeFakeModel
+              include Tire::Model::Search
+              include Tire::Model::Callbacks
+
+              mapping do
+                indexes :name, :as => Time.now
+              end
+
+            end
+
+          end
+
+        end
+
+      end
+
     end
 
   end


### PR DESCRIPTION
Hello guys,

This PR contains code to accept `Symbol`s and `lambda`s as as values for `:as` options when indexing. It contains tests covering this new code and also tests for the current implementation.

I have added validation for when `:as` fields are set to make sure that if the user gives it an unknown or invalid value an exception will be raised instead of failing silently (or breaking as in the case of `lambda`s).

I have also added information to the README file pertaining these changes when indexing documents.
