### PR TITLE
Add --data-binary as curl switch for logs when bulk loading (as per docs)

### DIFF
--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -117,7 +117,7 @@ module Tire
         end
 
       ensure
-        curl = %Q|curl -X POST "#{url}/_bulk" -d '{... data omitted ...}'|
+        curl = %Q|curl -X POST "#{url}/_bulk" --data-binary '{... data omitted: #{documents.size} documents ...}'|
         logged('BULK', curl)
       end
     end


### PR DESCRIPTION
The curl output should use --data-binary instead of -d when describing the action in the Tire log output. See http://www.elasticsearch.org/guide/reference/api/bulk.html.

Also adds count of omitted documents in log output.
