### PR TITLE
Specify a version of minitest that is compatible with mocha

### DIFF
--- a/tire.gemspec
+++ b/tire.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "bson_ext"
   s.add_development_dependency "redis-persistence"
   s.add_development_dependency "curb"
-  s.add_development_dependency "minitest"
+  s.add_development_dependency "minitest", "~> 2.12"
   s.add_development_dependency "turn", "~> 0.9" if defined?(RUBY_VERSION) && RUBY_VERSION > '1.9'
 
   # These gems are not needed for CI at <http://travis-ci.org/#!/karmi/tire>


### PR DESCRIPTION
This should fix the current Travis failures.
