### PR TITLE
Don't load all records into memory in the import rake task

### DIFF
--- a/lib/tire/tasks.rb
+++ b/lib/tire/tasks.rb
@@ -60,7 +60,7 @@ namespace :tire do
     STDOUT.sync = true
     puts "[IMPORT] Starting import for the '#{ENV['CLASS']}' class"
     tty_cols = 80
-    total    = klass.all.count rescue nil
+    total    = klass.count rescue nil
     offset   = (total.to_s.size*2)+8
     done     = 0
 


### PR DESCRIPTION
Since #381 the rake task to bulk import all the records loads all the records into memory to count the number of records. The change was done because what looks like what was a bug in ActiveRecord when using `default_scope` and sql grouping.

I'd like to get that change reverted back, otherwise there is no point on paginating the records from the DB since the all the records have been previously loaded into memory. I've also tried to replicate the `default_scope` bug with ActiveRecord v3.2.8 (latest released version) and it looks like the issue with count and grouping has been fixed.

We'll be soon doing a bulk import and the current task with this behaviour of loading all the records into memory is not practical
