### PR TITLE
Fix lambda error in README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -247,7 +247,7 @@ The best thing about `boolean` queries is that we can easily save these partial 
 to mix and reuse them later. So, we may define a query for the _tags_ property:
 
 ```ruby
-    tags_query = lambda do
+    tags_query = lambda do |boolean|
       boolean.should { string 'tags:ruby' }
       boolean.should { string 'tags:java' }
     end
@@ -256,7 +256,7 @@ to mix and reuse them later. So, we may define a query for the _tags_ property:
 And a query for the _published_on_ property:
 
 ```ruby
-    published_on_query = lambda do
+    published_on_query = lambda do |boolean|
       boolean.must   { string 'published_on:[2011-01-01 TO 2011-01-02]' }
     end
 ```


### PR DESCRIPTION
The two lambda examples raise this: ArgumentError: wrong number of arguments (1 for 0)
