### PR TITLE
Fixing elapsed time presentation on import task

### DIFF
--- a/lib/tire/tasks.rb
+++ b/lib/tire/tasks.rb
@@ -17,23 +17,6 @@ namespace :tire do
   DESC
   desc full_comment_import
   task :import do |t|
-
-    def elapsed_to_human(elapsed)
-      hour = 60*60
-      day  = hour*24
-
-      case elapsed
-      when 0..59
-        "#{sprintf("%1.5f", elapsed)} seconds"
-      when 60..hour-1
-        "#{elapsed/60} minutes and #{elapsed % 60} seconds"
-      when hour..day
-        "#{elapsed/hour} hours and #{elapsed % hour} minutes"
-      else
-        "#{elapsed/hour} hours"
-      end
-    end
-
     if ENV['CLASS'].to_s == ''
       puts '='*90, 'USAGE', '='*90, full_comment_import, ""
       exit(1)
@@ -95,7 +78,7 @@ namespace :tire do
       end
     end
 
-    puts "", '='*80, "Import finished in #{elapsed_to_human(elapsed)}"
+    puts "", '='*80, "Import finished in #{Tire::Utils.elapsed_to_human(elapsed)}"
   end
 
   namespace :index do

--- a/lib/tire/utils.rb
+++ b/lib/tire/utils.rb
@@ -12,6 +12,26 @@ module Tire
       URI.decode_www_form_component(s)
     end
 
+    def elapsed_to_human(elapsed)
+      hour = 60*60
+      day  = hour*24
+
+      seconds = sprintf("%1.5f", (elapsed % 60))
+      minutes = ((elapsed/60) % 60).to_i
+      hours   = (elapsed/hour).to_i
+
+      case elapsed
+      when 0..59
+        "#{seconds} seconds"
+      when 60..hour-1
+        "#{minutes} minutes and #{seconds} seconds"
+      when hour..day
+        "#{hours} hours and #{minutes} minutes"
+      else
+        "#{hours} hours"
+      end
+    end
+
     extend self
   end
 end

--- a/test/unit/tire_test.rb
+++ b/test/unit/tire_test.rb
@@ -118,6 +118,13 @@ module Tire
           assert_equal 'foo!',    Utils.unescape('foo%21')
         end
 
+        should "format time to print" do
+          assert_equal '30.51235 seconds'              , Utils.elapsed_to_human(30.5123478)
+          assert_equal '1 minutes and 10.51235 seconds', Utils.elapsed_to_human(70.5123478)
+          assert_equal '1 hours and 10 minutes'        , Utils.elapsed_to_human(4200.5123478)
+          assert_equal '25 hours'                      , Utils.elapsed_to_human(90600.5123478)
+        end
+
       end
     end
 


### PR DESCRIPTION
The time was being shown in a wrong way when the elapsed time is a float number.
