### PR TITLE
finders are not thread safe

### DIFF
--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -184,7 +184,7 @@ module Tire
       logged(id, curl)
     end
 
-    def retrieve(type, id)
+    def retrieve(type, id, options={})
       raise ArgumentError, "Please pass a document ID" unless id
 
       type      = Utils.escape(type)
@@ -192,12 +192,13 @@ module Tire
       @response = Configuration.client.get url
 
       h = MultiJson.decode(@response.body)
-      if Configuration.wrapper == Hash then h
+      wrapper = options[:wrapper] || Configuration.wrapper
+      if wrapper == Hash then h
       else
         return nil if h['exists'] == false
         document = h['_source'] || h['fields'] || {}
         document.update('id' => h['_id'], '_type' => h['_type'], '_index' => h['_index'], '_version' => h['_version'])
-        Configuration.wrapper.new(document)
+        wrapper.new(document)
       end
 
     ensure

--- a/lib/tire/model/persistence/finders.rb
+++ b/lib/tire/model/persistence/finders.rb
@@ -11,12 +11,10 @@ module Tire
 
           def find *args
             # TODO: Options like `sort`
-            old_wrapper = Tire::Configuration.wrapper
-            Tire::Configuration.wrapper self
             options = args.pop if args.last.is_a?(Hash)
             args.flatten!
             if args.size > 1
-              Tire::Search::Search.new(index.name) do |search|
+              Tire::Search::Search.new(index.name, wrapper: self) do |search|
                 search.query do |query|
                   query.ids(args, document_type)
                 end
@@ -25,35 +23,25 @@ module Tire
             else
               case args = args.pop
                 when Fixnum, String
-                  index.retrieve document_type, args
+                  index.retrieve document_type, args, wrapper: self
                 when :all, :first
                   send(args)
                 else
                   raise ArgumentError, "Please pass either ID as Fixnum or String, or :all, :first as an argument"
               end
             end
-          ensure
-            Tire::Configuration.wrapper old_wrapper
           end
 
           def all
             # TODO: Options like `sort`; Possibly `filters`
-            old_wrapper = Tire::Configuration.wrapper
-            Tire::Configuration.wrapper self
-            s = Tire::Search::Search.new(index.name).query { all }
+            s = Tire::Search::Search.new(index.name, wrapper: self).query { all }
             s.version(true).results
-          ensure
-            Tire::Configuration.wrapper old_wrapper
           end
 
           def first
             # TODO: Options like `sort`; Possibly `filters`
-            old_wrapper = Tire::Configuration.wrapper
-            Tire::Configuration.wrapper self
-            s = Tire::Search::Search.new(index.name).query { all }.size(1)
+            s = Tire::Search::Search.new(index.name, wrapper: self).query { all }.size(1)
             s.version(true).results.first
-          ensure
-            Tire::Configuration.wrapper old_wrapper
           end
 
         end


### PR DESCRIPTION
The methods defined in Tire::Model::Persistence::Finders are not thread-safe. They set the wrapper globally and expect it to be the same later. Concurrent finds attempt to wrap documents with the wrong wrapper.

This could be fixed by passing the :wrapper argument to search and retrieve from the finders instead of setting it globally. Index#retrieve would need to take a :wrapper option.
