### PR TITLE
pass document_type to all/first

### DIFF
--- a/lib/tire/model/persistence/finders.rb
+++ b/lib/tire/model/persistence/finders.rb
@@ -34,13 +34,13 @@ module Tire
 
           def all
             # TODO: Options like `sort`; Possibly `filters`
-            s = Tire::Search::Search.new(index.name, :wrapper => self).query { all }
+            s = Tire::Search::Search.new(index.name, :type => document_type, :wrapper => self).query { all }
             s.version(true).results
           end
 
           def first
             # TODO: Options like `sort`; Possibly `filters`
-            s = Tire::Search::Search.new(index.name, :wrapper => self).query { all }.size(1)
+            s = Tire::Search::Search.new(index.name, :type => document_type, :wrapper => self).query { all }.size(1)
             s.version(true).results.first
           end
 

--- a/test/integration/persistent_model_test.rb
+++ b/test/integration/persistent_model_test.rb
@@ -124,6 +124,32 @@ module Tire
 
       end
 
+      context "with many types in index" do
+
+        setup do
+          1.upto(3) { |number| PersistentArticleInIndex.create :title => "TestInIndex#{number}", :tags => ['in_index'] }
+          1.upto(3) { |number| PersistentArticle.create :title => "Test#{number}", :tags => [] }
+          PersistentArticle.index.refresh
+        end
+
+        should "returns all well typed documents" do
+          results = PersistentArticle.all
+
+          assert_equal 3, results.size
+          assert_equal [], results.first.tags
+
+          results = PersistentArticleInIndex.all
+
+          assert_equal 3, results.size
+          assert_equal ['in_index'], results.first.tags
+        end
+
+        should "returns first well typed documents" do
+          assert_equal [], PersistentArticle.first.tags
+          assert_equal ['in_index'], PersistentArticleInIndex.first.tags
+        end
+      end
+
     end
 
   end

--- a/test/models/persistent_article_in_index.rb
+++ b/test/models/persistent_article_in_index.rb
@@ -1,0 +1,16 @@
+# Example class with ElasticSearch persistence in index `persistent_articles`
+#
+# The `index` is `persistent_articles`
+#
+
+class PersistentArticleInIndex
+
+  include Tire::Model::Persistence
+
+  property :title
+  property :published_on
+  property :tags
+
+  index_name "persistent_articles"
+
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,6 +24,7 @@ require File.dirname(__FILE__) + '/models/active_model_article_with_custom_index
 require File.dirname(__FILE__) + '/models/active_record_models'
 require File.dirname(__FILE__) + '/models/article'
 require File.dirname(__FILE__) + '/models/persistent_article'
+require File.dirname(__FILE__) + '/models/persistent_article_in_index'
 require File.dirname(__FILE__) + '/models/persistent_article_in_namespace'
 require File.dirname(__FILE__) + '/models/persistent_article_with_casting'
 require File.dirname(__FILE__) + '/models/persistent_article_with_defaults'

--- a/test/unit/model_persistence_test.rb
+++ b/test/unit/model_persistence_test.rb
@@ -125,8 +125,13 @@ module Tire
           assert_equal ids.size, documents.count
         end
 
-        should "find all documents" do
-          Configuration.client.stubs(:get).returns(mock_response(@find_all.to_json))
+        should "find all type documents" do
+          Configuration.client.expects(:get).
+                               with do |url,payload|
+                                 url == "#{Configuration.url}/persistent_articles/persistent_article/_search?wrapper=PersistentArticle"
+                               end.
+                               times(3).
+                               returns(mock_response(@find_all.to_json))
           documents = PersistentArticle.all
 
           assert_equal 3, documents.count
@@ -134,8 +139,12 @@ module Tire
           assert_equal PersistentArticle.find(:all).map { |e| e.id }, PersistentArticle.all.map { |e| e.id }
         end
 
-        should "find first document" do
-          Configuration.client.expects(:get).returns(mock_response(@find_first.to_json))
+        should "find first type document" do
+          Configuration.client.expects(:get).
+                               with do |url,payload|
+                                 url == "#{Configuration.url}/persistent_articles/persistent_article/_search?size=1&wrapper=PersistentArticle"
+                               end.
+                               returns(mock_response(@find_first.to_json))
           document = PersistentArticle.first
 
           assert_equal 'First', document.attributes['title']


### PR DESCRIPTION
Ensure that first /all finders return well "typed" documents
