### PR TITLE
Using Tire::search without payload produces unexpected results

### DIFF
--- a/lib/tire/dsl.rb
+++ b/lib/tire/dsl.rb
@@ -10,6 +10,8 @@ module Tire
         Search::Search.new(indices, options, &block)
       else
         payload = case options
+          when {}      then
+            nil
           when Hash    then
             options
           when String  then

--- a/test/integration/dsl_search_test.rb
+++ b/test/integration/dsl_search_test.rb
@@ -15,6 +15,14 @@ module Tire
         assert_equal 2, s.results.facets['tags']['count']
       end
 
+      should "allow step-by-step query building" do
+        s = Tire.search('articles-test') { query { string 'ruby' } }
+        s.facet('tags') { filter :term, :tags => ['ruby'] }
+
+        assert_equal 2, s.results.count
+        assert_equal 2, s.results.facets['tags']['count']
+      end
+
       should "allow setting search payload later on" do
         s = Tire.search 'articles-test'
         s.query { string 'ruby' }

--- a/test/integration/dsl_search_test.rb
+++ b/test/integration/dsl_search_test.rb
@@ -15,6 +15,20 @@ module Tire
         assert_equal 2, s.results.facets['tags']['count']
       end
 
+      should "allow setting search payload later on" do
+        s = Tire.search 'articles-test'
+        s.query { string 'ruby' }
+        s.facet 'tags' do
+          filter :term, :tags => 'ruby'
+        end
+
+        # p s.to_hash
+        # p s.to_json
+        # p s.to_curl
+        assert_equal 2, s.results.count
+        assert_equal 2, s.results.facets['tags']['count']
+      end
+
     end
 
   end


### PR DESCRIPTION
Running this piece of code 

``` ruby
  s = Tire.search 'articles-test'
  s.query { string 'ruby' }
  s.facet 'tags' do
      filter :term, :tags => 'ruby'
  end
```

produces full index contents in result.

As I take it from documentation, building query step by step should be possible.
This pull request allows building query without specifying payload on Tire::search call
