### PR TITLE
Use an instance method as after_save/destroy parameter instead of a lambda.

### DIFF
--- a/lib/tire/model/callbacks.rb
+++ b/lib/tire/model/callbacks.rb
@@ -18,8 +18,8 @@ module Tire
         # Update index on model instance change or destroy.
         #
         if base.respond_to?(:after_save) && base.respond_to?(:after_destroy)
-          base.send :after_save,    lambda { tire.update_index }
-          base.send :after_destroy, lambda { tire.update_index }
+          base.send :after_save,    :_tire_update_index_callback
+          base.send :after_destroy, :_tire_update_index_callback
         end
 
         # Add neccessary infrastructure for the model, when missing in
@@ -34,6 +34,9 @@ module Tire
 
       end
 
+      def _tire_update_index_callback
+        tire.update_index
+      end
     end
 
   end

--- a/lib/tire/model/callbacks.rb
+++ b/lib/tire/model/callbacks.rb
@@ -34,6 +34,8 @@ module Tire
 
       end
 
+      # Update index
+      #
       def _tire_update_index_callback
         tire.update_index
       end


### PR DESCRIPTION
In some cases (unit testing), i don't want my models to perform any Tire callbacks. Now that the callback method is named, i can do the following:

``` ruby
before(:all) do
  Model.skip_callback :save, :after, :_tire_update_index_callback
end
```

I didn't write any tests because i don't change the behavior,  `update_index` is still called.
