### PR TITLE
Add count to index

### DIFF
--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -52,6 +52,11 @@ module Tire
       alias_name ? Alias.all(@name).select { |a| a.name == alias_name }.first : Alias.all(@name)
     end
 
+    def count
+      @response = Configuration.client.get("#{url}/_count")
+      MultiJson.decode(@response.body)['count']
+    end
+
     def mapping
       @response = Configuration.client.get("#{url}/_mapping")
       MultiJson.decode(@response.body)[@name]

--- a/test/integration/index_store_test.rb
+++ b/test/integration/index_store_test.rb
@@ -107,6 +107,26 @@ module Tire
 
     end
 
+    context "Counting documents in the index" do
+
+      teardown { Tire.index('articles-test-count').delete }
+
+      setup do
+        Tire.index 'articles-test-count' do
+          delete
+          create
+          store :id => 1, :title => 'One'
+          store :id => 2, :title => 'Two'
+          refresh
+        end
+      end
+
+      should "count documents in the index" do
+        assert_equal 2, Tire.index('articles-test-count').count
+      end
+
+    end
+
   end
 
 end


### PR DESCRIPTION
Hello - I've added support for _count on an index to retrieve the count of documents in the index.
