### PR TITLE
Make Results::Item#respond_to? conform to interface

### DIFF
--- a/lib/tire/results/item.rb
+++ b/lib/tire/results/item.rb
@@ -26,7 +26,7 @@ module Tire
         @attributes[method_name.to_sym]
       end
 
-      def respond_to?(method_name)
+      def respond_to?(method_name, include_private = false)
         @attributes.has_key?(method_name.to_sym) || super
       end
 


### PR DESCRIPTION
Ruby's native Object#respond_to? accepts a second boolean parameter to determine if private methods should be included.
