### PR TITLE
Allow arbitrary ordering of facet methods.

### DIFF
--- a/lib/tire/search/facet.rb
+++ b/lib/tire/search/facet.rb
@@ -11,52 +11,53 @@ module Tire
       def initialize(name, options={}, &block)
         @name    = name
         @options = options
+        @value = {}
         block.arity < 1 ? self.instance_eval(&block) : block.call(self) if block_given?
       end
 
       def terms(field, options={})
         size      = options.delete(:size) || 10
         all_terms = options.delete(:all_terms) || false
-        @value = if field.is_a?(Enumerable) and not field.is_a?(String)
-          { :terms => { :fields => field }.update({ :size => size, :all_terms => all_terms }).update(options) }
+        @value[:terms] = if field.is_a?(Enumerable) and not field.is_a?(String)
+          { :fields => field }.update({ :size => size, :all_terms => all_terms }).update(options)
         else
-          { :terms => { :field => field  }.update({ :size => size, :all_terms => all_terms }).update(options) }
+          { :field => field  }.update({ :size => size, :all_terms => all_terms }).update(options)
         end
         self
       end
 
       def date(field, options={})
         interval = options.delete(:interval) || 'day'
-        @value = { :date_histogram => { :field => field, :interval => interval }.update(options) }
+        @value[:date_histogram] = { :field => field, :interval => interval }.update(options)
         self
       end
 
       def range(field, ranges=[], options={})
-        @value = { :range => { :field => field, :ranges => ranges }.update(options) }
+        @value[:range] = { :field => field, :ranges => ranges }.update(options)
         self
       end
 
       def histogram(field, options={})
-        @value = { :histogram => (options.delete(:histogram) || {:field => field}.update(options)) }
+        @value[:histogram] = (options.delete(:histogram) || {:field => field}.update(options))
         self
       end
 
       def statistical(field, options={})
-        @value = { :statistical => (options.delete(:statistical) || {:field => field}.update(options)) }
+        @value[:statistical] = (options.delete(:statistical) || {:field => field}.update(options))
         self
       end
 
       def terms_stats(key_field, value_field, options={})
-        @value = { :terms_stats => {:key_field => key_field, :value_field => value_field}.update(options) }
+        @value[:terms_stats] = {:key_field => key_field, :value_field => value_field}.update(options)
         self
       end
 
       def query(&block)
-        @value = { :query => Query.new(&block).to_hash }
+        @value[:query] = Query.new(&block).to_hash
       end
 
       def filter(type, options={})
-        @value = { :filter => Filter.new(type, options) }
+        @value[:filter] = Filter.new(type, options)
         self
       end
 

--- a/test/unit/search_facet_test.rb
+++ b/test/unit/search_facet_test.rb
@@ -73,6 +73,15 @@ module Tire::Search
                         f['foo'][:facet_filter].to_json )
         end
 
+        should "allow arbitrary ordering of methods" do
+          f = Facet.new('foo'){
+            facet_filter :terms, :tags => ['ruby']
+            terms :published_on
+          }.to_hash
+
+          assert_equal( { :terms => {:tags => ['ruby'] }}.to_json, f['foo'][:facet_filter].to_json)
+        end
+
       end
 
       context "terms facet" do


### PR DESCRIPTION
Ran into an issue where calling facet_filter before other facet methods would fail:

``` ruby
facet "test" do
  facet_filter :range, { :published_on => { :from => '2011-01-01', :to => '2011-01-01' } }
  histogram :wt, :interval => 70
end
```

Reordering prevents the issue, but that seems a bit brittle to me.

Perhaps this PR is a bit safer?
