### PR TITLE
Fixes issue 529 - bulk importing mongoid documents gives an erroneous id

### DIFF
--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -415,7 +415,7 @@ module Tire
         when document.is_a?(Hash)
           document[:_id] || document['_id'] || document[:id] || document['id']
         when document.respond_to?(:id) && document.id != document.object_id
-          document.id
+          document.id.to_s
       end
       $VERBOSE = old_verbose
       id


### PR DESCRIPTION
Document#id with Mongoid returns a Moped::BSON::ObjectId instead if a string, which was confusing elasticsearch. Casting the id to a string fixes this issue.
