### PR TITLE
JRuby compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ rvm:
   - 1.9.3
   - 1.8.7
   - ree
-  - jruby-18mode
   - jruby-19mode
 
 env:
@@ -25,8 +24,6 @@ matrix:
     - rvm: 1.8.7
       env: TEST_COMMAND="rake test:integration"
     - rvm: ree
-      env: TEST_COMMAND="rake test:integration"
-    - rvm: jruby-18mode
       env: TEST_COMMAND="rake test:integration"
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ matrix:
       env: TEST_COMMAND="rake test:integration"
     - rvm: ree
       env: TEST_COMMAND="rake test:integration"
+    - rvm: jruby-18mode
+      env: TEST_COMMAND="rake test:integration"
 
 notifications:
   disable: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ rvm:
   - 1.9.3
   - 1.8.7
   - ree
+  - jruby-18mode
+  - jruby-19mode
 
 env:
   - TEST_COMMAND="rake test:unit"

--- a/Gemfile
+++ b/Gemfile
@@ -3,14 +3,6 @@ source "http://rubygems.org"
 # Specify your gem's dependencies in tire.gemspec
 gemspec
 
-platform :ruby do
-  gem "yajl-ruby",   "~> 1.0"
-  gem "sqlite3"
-  gem "bson_ext"
-  gem "curb"
-  gem "oj"
-end
-
 unless defined?(RUBY_VERSION) && RUBY_VERSION < '1.9'
   gem "turn", "~> 0.9"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,20 @@ source "http://rubygems.org"
 
 # Specify your gem's dependencies in tire.gemspec
 gemspec
+
+platform :ruby do
+  gem "yajl-ruby",   "~> 1.0"
+  gem "sqlite3"
+  gem "bson_ext"
+  gem "curb"
+  gem "oj"
+end
+
+unless defined?(RUBY_VERSION) && RUBY_VERSION < '1.9'
+  gem "turn", "~> 0.9"
+end
+
+platform :jruby do
+  gem "jdbc-sqlite3"
+  gem "activerecord-jdbcsqlite3-adapter"
+end

--- a/Gemfile
+++ b/Gemfile
@@ -18,4 +18,8 @@ end
 platform :jruby do
   gem "jdbc-sqlite3"
   gem "activerecord-jdbcsqlite3-adapter"
+  
+  if defined?(RUBY_VERSION) && RUBY_VERSION < '1.9'
+    gem "json"
+  end
 end

--- a/test/integration/active_record_searchable_test.rb
+++ b/test/integration/active_record_searchable_test.rb
@@ -7,7 +7,7 @@ module Tire
 
     def setup
       super
-      adapter = JRUBY ? 'jdbc-sqlite3' : 'sqlite3'
+      adapter = JRUBY ? 'jdbcsqlite3' : 'sqlite3'
       ActiveRecord::Base.establish_connection( :adapter => adapter, :database => ":memory:" )
 
       ActiveRecord::Migration.verbose = false

--- a/test/integration/active_record_searchable_test.rb
+++ b/test/integration/active_record_searchable_test.rb
@@ -7,8 +7,7 @@ module Tire
 
     def setup
       super
-      adapter = JRUBY ? 'jdbcsqlite3' : 'sqlite3'
-      ActiveRecord::Base.establish_connection( :adapter => adapter, :database => ":memory:" )
+      ActiveRecord::Base.establish_connection( :adapter => 'sqlite3', :database => ":memory:" )
 
       ActiveRecord::Migration.verbose = false
       ActiveRecord::Schema.define(:version => 1) do

--- a/test/integration/active_record_searchable_test.rb
+++ b/test/integration/active_record_searchable_test.rb
@@ -7,7 +7,8 @@ module Tire
 
     def setup
       super
-      ActiveRecord::Base.establish_connection( :adapter => 'sqlite3', :database => ":memory:" )
+      adapter = JRUBY ? 'jdbc-sqlite3' : 'sqlite3'
+      ActiveRecord::Base.establish_connection( :adapter => adapter, :database => ":memory:" )
 
       ActiveRecord::Migration.verbose = false
       ActiveRecord::Schema.define(:version => 1) do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,13 +6,24 @@ require 'bundler/setup'
 require 'pathname'
 require 'test/unit'
 
+JRUBY = defined?(RUBY_PLATFORM) && RUBY_PLATFORM == 'java'
+
 if ENV['JSON_LIBRARY']
   puts "Using '#{ENV['JSON_LIBRARY']}' JSON library"
   require ENV['JSON_LIBRARY']
+elsif JRUBY
+  require 'json'
 else
   require 'yajl/json_gem'
 end
-require 'sqlite3'
+
+if JRUBY
+  require 'jdbc/sqlite3'
+  require 'active_record'
+  require 'active_record/connection_adapters/jdbcsqlite3_adapter'
+else
+  require 'sqlite3'
+end
 
 require 'shoulda'
 require 'turn/autorun' unless ENV["TM_FILEPATH"] || defined?(RUBY_VERSION) && RUBY_VERSION < '1.9'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,7 +6,7 @@ require 'bundler/setup'
 require 'pathname'
 require 'test/unit'
 
-JRUBY = defined?(RUBY_PLATFORM) && RUBY_PLATFORM == 'java'
+JRUBY = defined?(JRUBY_VERSION)
 
 if ENV['JSON_LIBRARY']
   puts "Using '#{ENV['JSON_LIBRARY']}' JSON library"

--- a/test/unit/http_client_test.rb
+++ b/test/unit/http_client_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'tire/http/clients/curb'
 
 module Tire
   module HTTP
@@ -46,27 +45,31 @@ module Tire
 
       end
 
-      context "Curb" do
-        setup do
-          Configuration.client Client::Curb
+      if defined?(Curl)
+        require 'tire/http/clients/curb'
+        
+        context "Curb" do
+          setup do
+            Configuration.client Client::Curb
+          end
+
+          teardown do
+            Configuration.client Client::RestClient
+          end
+
+          should "use POST method if request body passed" do
+            ::Curl::Easy.any_instance.expects(:http_post)
+
+            response = Configuration.client.get "http://localhost:3000", '{ "query_string" : { "query" : "apple" }}'
+          end
+
+          should "use GET method if request body is nil" do
+            ::Curl::Easy.any_instance.expects(:http_get)
+
+            response = Configuration.client.get "http://localhost:9200/articles/article/1"
+          end
+
         end
-
-        teardown do
-          Configuration.client Client::RestClient
-        end
-
-        should "use POST method if request body passed" do
-          ::Curl::Easy.any_instance.expects(:http_post)
-
-          response = Configuration.client.get "http://localhost:3000", '{ "query_string" : { "query" : "apple" }}'
-        end
-
-        should "use GET method if request body is nil" do
-          ::Curl::Easy.any_instance.expects(:http_get)
-
-          response = Configuration.client.get "http://localhost:9200/articles/article/1"
-        end
-
       end
 
 

--- a/tire.gemspec
+++ b/tire.gemspec
@@ -42,6 +42,14 @@ Gem::Specification.new do |s|
   s.add_development_dependency "mongoid",      "~> 2.2"
   s.add_development_dependency "redis-persistence"
   s.add_development_dependency "faraday"
+  
+  unless defined?(JRUBY_VERSION)
+    s.add_development_dependency "yajl-ruby",   "~> 1.0"
+    s.add_development_dependency "sqlite3"
+    s.add_development_dependency "bson_ext"
+    s.add_development_dependency "curb"
+    s.add_development_dependency "oj"
+  end
 
   s.description = <<-DESC
    Tire is a Ruby client for the ElasticSearch search engine/database.

--- a/tire.gemspec
+++ b/tire.gemspec
@@ -35,18 +35,13 @@ Gem::Specification.new do |s|
   # = Development dependencies
   #
   s.add_development_dependency "bundler",     "~> 1.0"
-  s.add_development_dependency "yajl-ruby",   "~> 1.0"
   s.add_development_dependency "shoulda"
   s.add_development_dependency "mocha"
   s.add_development_dependency "minitest",     "~> 2.12"
   s.add_development_dependency "activerecord", ">= 3.0"
-  s.add_development_dependency "sqlite3"
   s.add_development_dependency "mongoid",      "~> 2.2"
-  s.add_development_dependency "bson_ext"
   s.add_development_dependency "redis-persistence"
-  s.add_development_dependency "curb"
-  s.add_development_dependency "oj"
-  s.add_development_dependency "turn", "~> 0.9" if defined?(RUBY_VERSION) && RUBY_VERSION > '1.9'
+  s.add_development_dependency "faraday"
 
   s.description = <<-DESC
    Tire is a Ruby client for the ElasticSearch search engine/database.


### PR DESCRIPTION
I'm thinking of using Tire on a project that will run in JRuby. I noticed the .travis.yml didn't include JRuby, so I  thought I'd try to get the tests running under JRuby. I was successful - the unit and integration tests all run successfully under JRuby.

This patch modifies the gem spec and test framework so it will bundle and run under JRuby. No change to the actual Tire implementation was necessary.
