### PR TITLE
Persistence: Fix invalid casting of nil in casted collections

### DIFF
--- a/lib/tire/model/persistence/attributes.rb
+++ b/lib/tire/model/persistence/attributes.rb
@@ -116,6 +116,8 @@ module Tire
           #
           def __cast_value(name, value)
             case
+              when value == nil
+                value
 
               when klass = self.class.property_types[name.to_sym]
                 if klass.is_a?(Array) && value.is_a?(Array)


### PR DESCRIPTION
When using `Tire::Model::Persistence` with a casted collection, casting fails when the value is nil.

Suggested patch will always cast nil value to nil (i.e. do nothing)

**Example**

``` ruby
class Job
  def initialize(params);                      @attributes = HashWithIndifferentAccess.new(params);  end
  def method_missing(method_name, *arguments); @attributes[method_name];                             end
  def as_json(*);                              @attributes;                                          end
end

class Company
  include Tire::Model::Persistence

  property :name,         :analyzer => 'keyword'  
  property :jobs,         :class    => [Job]
end
```

```
1.9.3p194 :006 > Company.create name: 'foo', jobs: nil
NoMethodError: undefined method `new' for [Job]:Array
    from /Users/barak/.rvm/gems/ruby-1.9.3-p194/gems/tire-0.5.2/lib/tire/model/persistence/attributes.rb:124:in `__cast_value'
    from /Users/barak/.rvm/gems/ruby-1.9.3-p194/gems/tire-0.5.2/lib/tire/model/persistence/attributes.rb:110:in `block in __update_attributes'
    from /Users/barak/.rvm/gems/ruby-1.9.3-p194/gems/tire-0.5.2/lib/tire/model/persistence/attributes.rb:110:in `each'
    from /Users/barak/.rvm/gems/ruby-1.9.3-p194/gems/tire-0.5.2/lib/tire/model/persistence/attributes.rb:110:in `__update_attributes'
...
```
