### PR TITLE
Add: Definition to check document exists?

### DIFF
--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -276,7 +276,7 @@ module Tire
     def update(type, id, payload={}, options={})
       raise ArgumentError, "Please pass a document type" unless type
       raise ArgumentError, "Please pass a document ID"   unless id
-      raise ArgumentError, "Please pass a script in the payload hash" unless payload[:script]
+      raise ArgumentError, "Please pass a script or partial document in the payload hash" unless payload[:script] || payload[:doc]
 
       type      = Utils.escape(type)
       url       = "#{self.url}/#{type}/#{id}/_update"

--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -21,6 +21,19 @@ module Tire
       logged('HEAD', curl)
     end
 
+    def document_exists?(type , id)
+      raise ArgumentError , "Please pass a document ID" unless id
+
+      type      = Utils.escape(type)
+      url       = "#{self.url}/#{type}/#{id}"
+
+      @response = Configuration.client.head("#{url}")
+      @response.success?
+    ensure
+      curl = %Q|curl -I "#{url}"|
+      logged('HEAD', curl)
+    end
+
     def delete
       @response = Configuration.client.delete url
       @response.success?


### PR DESCRIPTION
I think in some cases we need to check document existence without retrieving any document body,
in my case i use random ordered log for indexing sometime the main log object logged before the child object so we need to check the document existence before indexing. if document fail the log will go back to queue and if document exist will update document with the child log. 
