### PR TITLE
Added support for replication=async option when storing index document

### DIFF
--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -79,6 +79,7 @@ module Tire
 
       params[:parent]  = options[:parent]  if options[:parent]
       params[:routing] = options[:routing] if options[:routing]
+      params[:replication] = options[:replication] if options[:replication]
 
       params_encoded = params.empty? ? '' : "?#{params.to_param}"
 

--- a/test/unit/index_test.rb
+++ b/test/unit/index_test.rb
@@ -1007,6 +1007,19 @@ module Tire
         end
       end
 
+      context "when passing replication option" do
+
+        should "set the :replication option in the request parameters" do
+          Configuration.client.expects(:post).
+            with do |url, payload|
+              assert_equal "#{Configuration.url}/dummy/document/?replication=async", url
+            end.
+            returns(mock_response('{"ok":true,"_id":"test"}'))
+
+          @index.store({:title => 'Test'}, {:replication => 'async'})
+        end
+      end
+
       context "reindexing" do
         setup do
           @results = {


### PR DESCRIPTION
It's a very simple change to support Asynchronous Replication option when indexing a document on elasticsearch

-----------From Elastic Search Website---------
Asynchronous Replication
By default, the index operation only returns after all shards within the replication group have indexed the document (sync replication). To enable asynchronous replication, causing the replication process to take place in the background, set the replication parameter to async. When asynchronous replication is used, the index operation will return as soon as the operation succeeds on the primary shard.

Thanks
