### PR TITLE
Add: Definition to check if index has a document?

### DIFF
--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -21,6 +21,19 @@ module Tire
       logged('HEAD', curl)
     end
 
+    def has_document?(type , id)
+      raise ArgumentError , "Please pass a document ID" unless id
+
+      type      = Utils.escape(type)
+      url       = "#{self.url}/#{type}/#{id}"
+
+      @response = Configuration.client.head("#{url}")
+      @response.success?
+    ensure
+      curl = %Q|curl -I "#{url}"|
+      logged('HEAD', curl)
+    end
+
     def delete
       @response = Configuration.client.delete url
       @response.success?

--- a/test/unit/index_test.rb
+++ b/test/unit/index_test.rb
@@ -335,6 +335,38 @@ module Tire
 
       end
 
+      context "when checking a document" do
+        setup do
+          Configuration.reset :wrapper
+
+          Configuration.client.stubs(:post).with do |url, payload|
+                                              url     == "#{@index.url}/article/" &&
+                                              payload =~ /"title":"Test"/
+                                            end.
+                                            returns(mock_response('{"ok":true,"_id":"id-1"}'))
+          @index.store :type => 'article', :title => 'Test'
+        end
+
+        should "return a HTTP response" do
+          assert_respond_to @index, :response
+
+          Configuration.client.expects(:head).returns(mock_response('OK'))
+          @index.has_document? :article , 'id-1'
+          assert_equal      'OK', @index.response.body
+        end
+
+        should "return true when exists" do
+          Configuration.client.expects(:head).returns(mock_response(''))
+          assert @index.has_document? :article , 'id-1'
+        end
+
+        should "return false when does not exist" do
+          Configuration.client.expects(:head).returns(mock_response('', 404))
+          assert ! @index.has_document?(:article , 'id-1')
+        end
+
+      end
+
       context "when retrieving" do
 
         setup do


### PR DESCRIPTION
resubmit karmi/tire#567

In more simple cases when we using batch processing with random ordered queue we need to check if main data from database has been indexed before index data from another source like log or messaging.

ps: sorry for miss typed commit message
