### PR TITLE
Casting times formatted with either a "Z" or a time zone offset

### DIFF
--- a/lib/tire/model/persistence/attributes.rb
+++ b/lib/tire/model/persistence/attributes.rb
@@ -134,7 +134,7 @@ module Tire
 
               else
                 # Strings formatted as <http://en.wikipedia.org/wiki/ISO8601> are automatically converted to Time
-                value = Time.parse(value) if value.is_a?(String) && value =~ /^\d{4}[\/\-]\d{2}[\/\-]\d{2}T\d{2}\:\d{2}\:\d{2}Z$/
+                value = Time.parse(value) if value.is_a?(String) && value =~ /^\d{4}[\/\-]\d{2}[\/\-]\d{2}T\d{2}\:\d{2}\:\d{2}/
                 value
             end
           end

--- a/test/unit/model_persistence_test.rb
+++ b/test/unit/model_persistence_test.rb
@@ -307,8 +307,14 @@ module Tire
             assert_equal '4chan',       article.comments.first.nick
           end
 
-          should "automatically format strings in UTC format as Time" do
+          should "automatically format strings in ISO8601 with UTC designator as Time" do
             article = PersistentArticle.new :published_on => '2011-11-01T23:00:00Z'
+            assert_instance_of Time, article.published_on
+            assert_equal 2011, article.published_on.year
+          end
+
+          should "automatically format strings in ISO8601 with time zone a time zone offset as Time" do
+            article = PersistentArticle.new :published_on => '2011-05-16T00:00:00+01:00'
             assert_instance_of Time, article.published_on
             assert_equal 2011, article.published_on.year
           end


### PR DESCRIPTION
The casting of strings to Time in persistence/attributes.rb assumed strings with a trailing "Z" (i.e. in UTC time). This pull request adds support for strings with a time zone offset (e.g. +01:00). 
