### PR TITLE
Allow Tire to infer the wrapper class

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -357,6 +357,11 @@ If that seems like a great idea to you, there's a big chance you already have su
 
 One would bet it's an `ActiveRecord` or `ActiveModel` class, containing model of your Rails application.
 
+If your search results return items with different classes, you can set
+`Tire.configuration.wrapper` to `:infer` and Tire will try to use the class
+from the item `_type` property (i.e. if `_type` is `article` the inferred
+class will be `Article`).
+
 Fortunately, _Tire_ makes blending _Elasticsearch_ features into your models trivially possible.
 
 

--- a/test/unit/results_collection_test.rb
+++ b/test/unit/results_collection_test.rb
@@ -149,6 +149,14 @@ module Tire
           assert_equal   'Test',  article.title
         end
 
+        should "allow wrapping hits in inferred class" do
+          Configuration.wrapper(:infer)
+
+          article =  Results::Collection.new(@response).first
+          assert_kind_of Article, article
+          assert_equal   'Test',  article.title
+        end
+
         should "return score" do
           document =  Results::Collection.new(@response).first
           assert_equal 0.5, document._score


### PR DESCRIPTION
Set `Tire.configuration.wrapper` to `:infer` and Tire will infer the wrapper
class for search results.

This is useful when your search query returns results with different classes.
