### PR TITLE
In Rails 4 pre-release, Class.model_name now responds with an instance of ActiveModel::Name

### DIFF
--- a/lib/tire/model/naming.rb
+++ b/lib/tire/model/naming.rb
@@ -75,7 +75,7 @@ module Tire
         #
         def document_type name=nil
           @document_type = name if name
-          @document_type || klass.model_name.underscore
+          @document_type || klass.model_name.to_s.underscore
         end
       end
 

--- a/lib/tire/model/persistence/storage.rb
+++ b/lib/tire/model/persistence/storage.rb
@@ -34,7 +34,7 @@ module Tire
           end
 
           def update_index
-            send :_run_update_elasticsearch_index_callbacks do
+            run_callbacks :update_elasticsearch_index do
               if destroyed?
                 index.remove self
               else

--- a/lib/tire/model/search.rb
+++ b/lib/tire/model/search.rb
@@ -141,7 +141,7 @@ module Tire
         # It will also execute any `<after|before>_update_elasticsearch_index` callback hooks.
         #
         def update_index
-          instance.send :_run_update_elasticsearch_index_callbacks do
+          instance.run_callbacks :update_elasticsearch_index do
             if instance.destroyed?
               index.remove instance
             else


### PR DESCRIPTION
Turns out there was a change in Rails 4 and Class.model_name now responds with an instance of ActiveModel::Name as opposed to a string (as it did in Rails 3)

See more details here: https://gist.github.com/4544950
Here's the rails commit that did it: https://github.com/rails/rails/commit/72cbccb5f77ebbd56b3b82a3eda99b6d640d8084

Resolves: https://github.com/karmi/tire/issues/585
