### PR TITLE
Safe response body parsing

### DIFF
--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -440,7 +440,12 @@ module Tire
     protected
 
     def parse_response(response)
-      MultiJson.decode(response.body) if response.success?
+      if response.success?
+        MultiJson.decode(response.body)
+      else
+        Configuration.logger.log_response(response.code, nil, response.body) if Configuration.logger
+        nil
+      end
     end
 
   end

--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -54,12 +54,12 @@ module Tire
 
     def mapping
       @response = Configuration.client.get("#{url}/_mapping")
-      MultiJson.decode(@response.body)[@name]
+      (parse_response(@response) || {})[@name]
     end
 
     def settings
       @response = Configuration.client.get("#{url}/_settings")
-      MultiJson.decode(@response.body)[@name]['settings']
+      (parse_response(@response) || {})[@name]['settings']
     end
 
     def store(*args)
@@ -85,7 +85,8 @@ module Tire
       url  = id ? "#{self.url}/#{type}/#{id}#{params_encoded}" : "#{self.url}/#{type}/#{params_encoded}"
 
       @response = Configuration.client.post url, document
-      MultiJson.decode(@response.body)
+      
+      parse_response(@response)
     ensure
       curl = %Q|curl -X POST "#{url}" -d '#{document}'|
       logged([type, id].join('/'), curl)
@@ -238,7 +239,7 @@ module Tire
 
       url    = "#{self.url}/#{type}/#{id}"
       result = Configuration.client.delete url
-      MultiJson.decode(result.body) if result.success?
+      parse_response(result)
 
     ensure
       curl = %Q|curl -X DELETE "#{url}"|
@@ -259,11 +260,11 @@ module Tire
 
       @response = Configuration.client.get "#{url}#{params_encoded}"
 
-      h = MultiJson.decode(@response.body)
+      h = parse_response(@response)
       wrapper = options[:wrapper] || Configuration.wrapper
       if wrapper == Hash then h
       else
-        return nil if h['exists'] == false
+        return nil if !h || (h.has_key?('exists') && h['exists'] == false)
         document = h['_source'] || h['fields'] || {}
         document.update('id' => h['_id'], '_type' => h['_type'], '_index' => h['_index'], '_version' => h['_version'])
         wrapper.new(document)
@@ -283,7 +284,7 @@ module Tire
       url       = "#{self.url}/#{type}/#{id}/_update"
       url      += "?#{options.to_param}" unless options.keys.empty?
       @response = Configuration.client.post url, MultiJson.encode(payload)
-      MultiJson.decode(@response.body)
+      parse_response(@response)
 
     ensure
       curl = %Q|curl -X POST "#{url}" -d '#{MultiJson.encode(payload, :pretty => Configuration.pretty)}'|
@@ -301,7 +302,7 @@ module Tire
     def open(options={})
       # TODO: Remove the duplication in the execute > rescue > ensure chain
       @response = Configuration.client.post "#{url}/_open", MultiJson.encode(options)
-      MultiJson.decode(@response.body)['ok']
+      (parse_response(@response) || {})['ok']
 
     ensure
       curl = %Q|curl -X POST "#{url}/_open"|
@@ -310,7 +311,7 @@ module Tire
 
     def close(options={})
       @response = Configuration.client.post "#{url}/_close", MultiJson.encode(options)
-      MultiJson.decode(@response.body)['ok']
+      (parse_response(@response) || {})['ok']
 
     ensure
       curl = %Q|curl -X POST "#{url}/_close"|
@@ -321,7 +322,7 @@ module Tire
       options = {:pretty => true}.update(options)
       params  = options.to_param
       @response = Configuration.client.get "#{url}/_analyze?#{params}", text
-      @response.success? ? MultiJson.decode(@response.body) : false
+      @response.success? ? parse_response(@response) : false
 
     ensure
       curl = %Q|curl -X GET "#{url}/_analyze?#{params}" -d '#{text}'|
@@ -332,7 +333,7 @@ module Tire
       options[:query] = Search::Query.new(&block).to_hash if block_given?
 
       @response = Configuration.client.put "#{Configuration.url}/_percolator/#{@name}/#{name}", MultiJson.encode(options)
-      MultiJson.decode(@response.body)['ok']
+      (parse_response(@response) || {})['ok']
 
     ensure
       curl = %Q|curl -X PUT "#{Configuration.url}/_percolator/#{@name}/#{name}?pretty" -d '#{MultiJson.encode(options, :pretty => Configuration.pretty)}'|
@@ -341,7 +342,7 @@ module Tire
 
     def unregister_percolator_query(name)
       @response = Configuration.client.delete "#{Configuration.url}/_percolator/#{@name}/#{name}"
-      MultiJson.decode(@response.body)['ok']
+      (parse_response(@response) || {})['ok']
 
     ensure
       curl = %Q|curl -X DELETE "#{Configuration.url}/_percolator/#{@name}"|
@@ -360,7 +361,7 @@ module Tire
       payload.update( :query => query ) if query
 
       @response = Configuration.client.get "#{url}/#{type}/_percolate", MultiJson.encode(payload)
-      MultiJson.decode(@response.body)['matches']
+      (parse_response(@response) || {})['matches']
 
     ensure
       curl = %Q|curl -X GET "#{url}/#{type}/_percolate?pretty" -d '#{MultiJson.encode(payload, :pretty => Configuration.pretty)}'|
@@ -434,6 +435,12 @@ module Tire
         else raise ArgumentError, "Please pass a JSON string or object with a 'to_indexed_json' method," +
                                   "'#{document.class}' given."
       end
+    end
+
+    protected
+
+    def parse_response(response)
+      MultiJson.decode(response.body) if response.success?
     end
 
   end


### PR DESCRIPTION
Sometimes the ElasticSearch server returns an empty body response with code 404. Parsing an empty string makes MultiJson throwing an exception, which is not expected result in that case.
With following changes Tire::Index will try to parse response body only on success. Otherwise `nil` will be returned.
