### PR TITLE
problem with persisted? (_version) on new object with custom id  

### DIFF
--- a/lib/tire/model/persistence.rb
+++ b/lib/tire/model/persistence.rb
@@ -45,7 +45,7 @@ module Tire
 
           ['_score', '_type', '_index', '_version', 'sort', 'highlight', '_explanation'].each do |attr|
             define_method("#{attr}=") { |value| @attributes ||= {}; @attributes[attr] = value }
-            define_method("#{attr}")  { @attributes[attr] }
+            define_method("#{attr}")  { @attributes.has_key?(attr) ? @attributes[attr] : nil }
           end
 
           def self.search(*args, &block)


### PR DESCRIPTION
[FIX] Tire Persistence - when id was set for new object, then on save persisted? was called and asked for _version attribute, but it raised exception on missing key in hash.
