### PR TITLE
Load includes with mongoid

### DIFF
--- a/lib/tire/results/collection.rb
+++ b/lib/tire/results/collection.rb
@@ -148,7 +148,15 @@ module Tire
       end
 
       def __find_records_by_ids(klass, ids)
-        @options[:load] === true ? klass.find(ids) : klass.find(ids, @options[:load])
+        if @options[:load] === true
+          klass.find(ids)
+        else
+          if @options[:load][:include] && defined?(Mongoid) && klass < Mongoid::Document
+            klass.includes(@options[:load][:include]).find(ids)
+          else
+            klass.find(ids, @options[:load])
+          end
+        end
       end
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -46,6 +46,7 @@ require File.dirname(__FILE__) + '/models/active_model_article_with_custom_docum
 require File.dirname(__FILE__) + '/models/active_model_article_with_custom_index_name'
 require File.dirname(__FILE__) + '/models/active_record_models'
 require File.dirname(__FILE__) + '/models/article'
+require File.dirname(__FILE__) + '/models/mongoid_models'
 require File.dirname(__FILE__) + '/models/persistent_article'
 require File.dirname(__FILE__) + '/models/persistent_article_in_index'
 require File.dirname(__FILE__) + '/models/persistent_article_in_namespace'

--- a/test/unit/results_collection_test.rb
+++ b/test/unit/results_collection_test.rb
@@ -306,61 +306,64 @@ module Tire
       end
 
       context "with eager loading" do
-        setup do
-          @response = { 'hits' => { 'hits' => [ {'_id' => 1, '_type' => 'active_record_article'},
-                                                {'_id' => 2, '_type' => 'active_record_article'},
-                                                {'_id' => 3, '_type' => 'active_record_article'}] } }
-          ActiveRecordArticle.stubs(:inspect).returns("<ActiveRecordArticle>")
-        end
-
-        should "load the records via model find method from database" do
-          ActiveRecordArticle.expects(:find).with([1,2,3]).
-                              returns([ Results::Item.new(:id => 3),
-                                        Results::Item.new(:id => 1),
-                                        Results::Item.new(:id => 2)  ])
-          Results::Collection.new(@response, :load => true).results
-        end
-
-        should "pass the :load option Hash to model find method" do
-          ActiveRecordArticle.expects(:find).with([1,2,3], :include => 'comments').
-                              returns([ Results::Item.new(:id => 3),
-                                        Results::Item.new(:id => 1),
-                                        Results::Item.new(:id => 2)  ])
-          Results::Collection.new(@response, :load => { :include => 'comments' }).results
-        end
-
-        should "preserve the order of records returned from search" do
-          ActiveRecordArticle.expects(:find).with([1,2,3]).
-                              returns([ Results::Item.new(:id => 3),
-                                        Results::Item.new(:id => 1),
-                                        Results::Item.new(:id => 2)  ])
-          assert_equal [1,2,3], Results::Collection.new(@response, :load => true).results.map(&:id)
-        end
-
-        should "raise error when model class cannot be inferred from _type" do
-          assert_raise(NameError) do
-            response = { 'hits' => { 'hits' => [ {'_id' => 1, '_type' => 'hic_sunt_leones'}] } }
-            Results::Collection.new(response, :load => true).results
+        context "with ActiveRecord" do
+          setup do
+            @response = { 'hits' => { 'hits' => [ {'_id' => 1, '_type' => 'active_record_article'},
+                                                  {'_id' => 2, '_type' => 'active_record_article'},
+                                                  {'_id' => 3, '_type' => 'active_record_article'}] } }
+            ActiveRecordArticle.stubs(:inspect).returns("<ActiveRecordArticle>")
           end
-        end
 
-        should "raise error when _type is missing" do
-          assert_raise(NoMethodError) do
-            response = { 'hits' => { 'hits' => [ {'_id' => 1}] } }
-            Results::Collection.new(response, :load => true).results
+          should "load the records via model find method from database" do
+            ActiveRecordArticle.expects(:find).with([1,2,3]).
+                                returns([ Results::Item.new(:id => 3),
+                                          Results::Item.new(:id => 1),
+                                          Results::Item.new(:id => 2)  ])
+            Results::Collection.new(@response, :load => true).results
           end
-        end
 
-        should "return empty array for empty hits" do
-          response = { 'hits'  => {
-                         'hits' => [],
-                         'total' => 4
-                       },
-                       'took'  => 1 }
-          @collection = Results::Collection.new( response, :load => true )
-          assert @collection.empty?, 'Collection should be empty'
-          assert @collection.results.empty?, 'Collection results should be empty'
-          assert_equal 0, @collection.size
+          should "pass the :load option Hash to model find method" do
+            ActiveRecordArticle.expects(:find).with([1,2,3], :include => 'comments').
+                                returns([ Results::Item.new(:id => 3),
+                                          Results::Item.new(:id => 1),
+                                          Results::Item.new(:id => 2)  ])
+            Results::Collection.new(@response, :load => { :include => 'comments' }).results
+          end
+
+          should "preserve the order of records returned from search" do
+            ActiveRecordArticle.expects(:find).with([1,2,3]).
+                                returns([ Results::Item.new(:id => 3),
+                                          Results::Item.new(:id => 1),
+                                          Results::Item.new(:id => 2)  ])
+            assert_equal [1,2,3], Results::Collection.new(@response, :load => true).results.map(&:id)
+          end
+
+          should "raise error when model class cannot be inferred from _type" do
+            assert_raise(NameError) do
+              response = { 'hits' => { 'hits' => [ {'_id' => 1, '_type' => 'hic_sunt_leones'}] } }
+              Results::Collection.new(response, :load => true).results
+            end
+          end
+
+          should "raise error when _type is missing" do
+            assert_raise(NoMethodError) do
+              response = { 'hits' => { 'hits' => [ {'_id' => 1}] } }
+              Results::Collection.new(response, :load => true).results
+            end
+          end
+
+          should "return empty array for empty hits" do
+            response = { 'hits'  => {
+                           'hits' => [],
+                           'total' => 4
+                         },
+                         'took'  => 1 }
+            @collection = Results::Collection.new( response, :load => true )
+            assert @collection.empty?, 'Collection should be empty'
+            assert @collection.results.empty?, 'Collection results should be empty'
+            assert_equal 0, @collection.size
+          end
+
         end
 
       end

--- a/test/unit/results_collection_test.rb
+++ b/test/unit/results_collection_test.rb
@@ -366,6 +366,24 @@ module Tire
 
         end
 
+        context "with Mongoid" do
+          setup do
+            @response = { 'hits' => { 'hits' => [ {'_id' => 1, '_type' => 'mongoid_article'},
+                                                  {'_id' => 2, '_type' => 'mongoid_article'},
+                                                  {'_id' => 3, '_type' => 'mongoid_article'}] } }
+          end
+
+          should "pass the :load option Hash to model find and includes method" do
+            articles = [MongoidArticle.new(:id => 3), MongoidArticle.new(:id => 1), MongoidArticle.new(:id => 2)]
+            criteria = mock("Criteria")
+            criteria.expects(:find).with([1, 2, 3]).returns(articles)
+            MongoidArticle.expects(:includes).with('comments').returns(criteria)
+
+            Results::Collection.new(@response, :load => { :include => 'comments' }).results
+          end
+
+        end
+
       end
 
     end

--- a/test/unit/results_collection_test.rb
+++ b/test/unit/results_collection_test.rb
@@ -321,7 +321,7 @@ module Tire
           Results::Collection.new(@response, :load => true).results
         end
 
-        should "pass the :load option Hash to model find metod" do
+        should "pass the :load option Hash to model find method" do
           ActiveRecordArticle.expects(:find).with([1,2,3], :include => 'comments').
                               returns([ Results::Item.new(:id => 3),
                                         Results::Item.new(:id => 1),


### PR DESCRIPTION
before this PR the loading will be done by:

``` ruby
klass.find(ids, @options[:load])
```

but this doesn't work with Mongoid, Mongoid need's this way:

``` ruby
klass.find(ids).includes(@options[:load][:include])
```

This also closes #282 
