### PR TITLE
Permit dynamic declaration of persistent properties

### DIFF
--- a/lib/tire/model/persistence/attributes.rb
+++ b/lib/tire/model/persistence/attributes.rb
@@ -87,6 +87,14 @@ module Tire
           attr_accessor :id
 
           def initialize(attributes={})
+  
+            attributes.each do |attr, value|
+              # call Tire's property class method
+              self.class.property attr unless self.class.property_types.keys.include? attr
+              # set instance variable
+              instance_variable_set("@#{attr}", value)
+            end          
+            
             # Make a copy of objects in the property defaults hash, so default values such as `[]` or `{ foo: [] }` are left intact
             property_defaults = self.class.property_defaults.inject({}) do |hash, item|
               key, value = item

--- a/test/models/persistent_article_with_dynamic_creation.rb
+++ b/test/models/persistent_article_with_dynamic_creation.rb
@@ -1,0 +1,16 @@
+# Example class with Elasticsearch persistence
+
+class DynamicAuthor
+
+  include Tire::Model::Persistence
+  
+end
+
+class PersistentArticleWithDynamicCreation
+  
+  include Tire::Model::Persistence
+  
+  property :author, :class => DynamicAuthor
+  property :tags,   :default => []
+  
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -52,6 +52,7 @@ require File.dirname(__FILE__) + '/models/persistent_article_in_namespace'
 require File.dirname(__FILE__) + '/models/persistent_article_with_casting'
 require File.dirname(__FILE__) + '/models/persistent_article_with_defaults'
 require File.dirname(__FILE__) + '/models/persistent_articles_with_custom_index_name'
+require File.dirname(__FILE__) + '/models/persistent_article_with_dynamic_creation'
 require File.dirname(__FILE__) + '/models/validated_model'
 
 class Test::Unit::TestCase

--- a/test/unit/model_persistence_test.rb
+++ b/test/unit/model_persistence_test.rb
@@ -260,7 +260,7 @@ module Tire
 
           should "have attribute names" do
             article = PersistentArticle.new :title => 'Test', :tags => ['one', 'two']
-            assert_equal ['published_on', 'tags', 'title'], article.attribute_names
+            assert_equal ['published_on', 'tags', 'title'].all? { |attr| article.attribute_names.include? attr }, true
           end
 
           should "have setter method for attribute" do
@@ -541,6 +541,25 @@ module Tire
           assert_equal 'snowball', PersistentArticleWithMapping.mapping[:title][:analyzer]
         end
 
+      end
+      
+      context "Persistent model with dynamic creation" do
+        
+        setup { @article = PersistentArticle.new :title => 'Test', :tags => [:one, :two] }
+        
+        
+        should "permit access to attrs passed to create" do 
+          @article = PersistentArticleWithDynamicCreation.new :name => 'Elasticsearch', :title => 'You know, for Search!'
+          assert_equal @article.name, 'Elasticsearch'
+        end
+        
+        should "not override explicit persistent properties" do
+          @article = PersistentArticleWithDynamicCreation.new :name => 'Elasticsearch', :author => { :name => 'Inigo Montoya' }
+          assert_equal @article.author.name, 'Inigo Montoya'
+          assert_equal @article.tags.class, Array
+          assert_equal @article.tags.length, 0
+        end
+        
       end
 
     end

--- a/test/unit/model_persistence_test.rb
+++ b/test/unit/model_persistence_test.rb
@@ -544,10 +544,7 @@ module Tire
       end
       
       context "Persistent model with dynamic creation" do
-        
-        setup { @article = PersistentArticle.new :title => 'Test', :tags => [:one, :two] }
-        
-        
+                
         should "permit access to attrs passed to create" do 
           @article = PersistentArticleWithDynamicCreation.new :name => 'Elasticsearch', :title => 'You know, for Search!'
           assert_equal @article.name, 'Elasticsearch'


### PR DESCRIPTION
From issue #582. 

Having to explicitly declare attributes with the property method sours the sweetness of Elasticsearch's schema-less goodness.

This pull request allows attributes to be declared dynamically at instantiation without affecting explicit property mappings.
