### PR TITLE
Callback Improvement

### DIFF
--- a/lib/tire/model/callbacks.rb
+++ b/lib/tire/model/callbacks.rb
@@ -1,3 +1,4 @@
+require 'set'
 module Tire
   module Model
 
@@ -11,6 +12,10 @@ module Tire
     #
     module Callbacks
 
+			def self.save_only_on_indexed
+				true
+			end
+
       # A hook triggered by the `include Tire::Model::Callbacks` statement in the model.
       #
       def self.included(base)
@@ -18,9 +23,22 @@ module Tire
         # Update index on model instance change or destroy.
         #
         if base.respond_to?(:after_save) && base.respond_to?(:after_destroy)
-          base.send :after_save,    lambda { tire.update_index }
+          base.send :after_save,    lambda { tire.update_index if should_save? }
           base.send :after_destroy, lambda { tire.update_index }
         end
+
+				def should_save?
+					if self.respond_to?(:changes) && self.class.save_only_on_index_changes?
+						unless defined? @indexed_properties
+							raise "No tire index mapping has been defined for #{self.class.name}" if self.tire.index.mapping.nil?	
+							@indexed_properties = Set.new(self.tire.index.mapping[self.class.name.underscore]['properties'].keys)
+						end	
+						changed_properties = self.changes.keys
+						changed_properties.any? {|changed_property| @indexed_properties.include? changed_property } 
+					else
+						return true
+					end
+				end
 
         # Add neccessary infrastructure for the model, when missing in
         # some half-baked ActiveModel implementations.
@@ -32,7 +50,18 @@ module Tire
           end
         end
 
+				base.extend(ClassMethods)
       end
+
+			module ClassMethods
+				def save_only_on_index_changes(should_change = false)
+					@save_only_on_index_changes = should_change
+				end
+
+				def save_only_on_index_changes?
+					@save_only_on_index_changes ||= false
+				end
+			end
 
     end
 

--- a/lib/tire/model/callbacks.rb
+++ b/lib/tire/model/callbacks.rb
@@ -12,10 +12,6 @@ module Tire
     #
     module Callbacks
 
-			def self.save_only_on_indexed
-				true
-			end
-
       # A hook triggered by the `include Tire::Model::Callbacks` statement in the model.
       #
       def self.included(base)

--- a/lib/tire/model/callbacks.rb
+++ b/lib/tire/model/callbacks.rb
@@ -1,4 +1,3 @@
-require 'set'
 module Tire
   module Model
 
@@ -24,13 +23,12 @@ module Tire
         end
 
 				def should_save?
-					if self.respond_to?(:changes) && self.class.save_only_on_index_changes?
+					if self.respond_to?(:changes) && self.class.should_tire_only_update_on_index_changes?
 						unless defined? @indexed_properties
 							raise "No tire index mapping has been defined for #{self.class.name}" if self.tire.index.mapping.nil?	
-							@indexed_properties = Set.new(self.tire.index.mapping[self.class.name.underscore]['properties'].keys)
+							@indexed_properties = self.tire.index.mapping[self.class.name.underscore]['properties'].keys
 						end	
-						changed_properties = self.changes.keys
-						changed_properties.any? {|changed_property| @indexed_properties.include? changed_property } 
+						(@indexed_properties & self.changes.keys).any?
 					else
 						return true
 					end
@@ -50,12 +48,12 @@ module Tire
       end
 
 			module ClassMethods
-				def save_only_on_index_changes(should_change = false)
-					@save_only_on_index_changes = should_change
+				def should_tire_only_update_on_index_changes(should_change = false)
+					@should_tire_only_update_on_index_changes = should_change
 				end
 
-				def save_only_on_index_changes?
-					@save_only_on_index_changes ||= false
+				def should_tire_only_update_on_index_changes?
+					@should_tire_only_update_on_index_changes ||= false
 				end
 			end
 

--- a/test/unit/model_callbacks_test.rb
+++ b/test/unit/model_callbacks_test.rb
@@ -50,7 +50,7 @@ end
 class ModelWithCallbackUpdatedOnIndexedAttributeChanges < ModelTwo
 	include ActiveModel::Dirty
 	define_attribute_methods [:name]
-	save_only_on_index_changes true
+	should_tire_only_update_on_index_changes true
 
 	def name
 		@name

--- a/test/unit/model_callbacks_test.rb
+++ b/test/unit/model_callbacks_test.rb
@@ -47,6 +47,26 @@ class ModelWithoutTireAutoCallbacks
   def destroy; _run_destroy_callbacks {}; end
 end
 
+class ModelWithCallbackUpdatedOnIndexedAttributeChanges < ModelTwo
+	include ActiveModel::Dirty
+	define_attribute_methods [:name]
+	save_only_on_index_changes true
+
+	def name
+		@name
+	end
+
+	def name=(val)
+		name_will_change! unless val == @name
+		@name = val
+	end
+
+	tire.mapping do
+		indexes :name,   analyzer: 'snowball'
+	end
+
+end
+
 module Tire
   module Model
 
@@ -73,6 +93,24 @@ module Tire
           m.save
           m.destroy
         end
+
+				should "execute both callbacks when changes to the index exist" do
+					m = ModelWithCallbackUpdatedOnIndexedAttributeChanges.new
+					m.tire.expects(:update_index).twice
+
+					m.name = 'Django'
+
+					m.save
+					m.destroy
+				end
+
+				should "execute only the destroy callback when changes to the index do not exist" do
+					m = ModelWithCallbackUpdatedOnIndexedAttributeChanges.new
+					m.tire.expects(:update_index).once
+
+					m.save
+					m.destroy
+				end
 
       end
 


### PR DESCRIPTION
Currently, Model::Callbacks updates the index on any change to the model even if the attributes being changed are not part of the index being updated. This PR includes changes that allow the user to specify if the Model should update ElasticSearch on indexed-attribute changes only.

In the below example, only changes to the :name attribute will cause the ElasticSearch server to be updated.

```
class SomeModel < ActiveRecord
  should_tire_only_update_on_index_changes true
  tire.mapping do
    indexes :name, analyzer: 'snowball'
  end
end    
```
