### PR TITLE
Remove TBLDECWWWCOMP_ constant before redefining it.

### DIFF
--- a/lib/tire/rubyext/ruby_1_8.rb
+++ b/lib/tire/rubyext/ruby_1_8.rb
@@ -1,1 +1,3 @@
-require 'tire/rubyext/uri_escape'
+unless defined?(URI.encode_www_form_component) && defined?(URI.decode_www_form_component)
+  require 'tire/rubyext/uri_escape'
+end


### PR DESCRIPTION
When using tire under ruby 1.8 the following warning is logged (twice as shown).

``` bash
...uri_escape.rb:14: warning: already initialized constant TBLENCWWWCOMP_
...uri_escape.rb:15: warning: already initialized constant TBLENCWWWCOMP_
```

This pull request removes the constant before adding to quiet the warning.
It and removes the duplicate init.
