### PR TITLE
Ignore :payload options for Search#params.

### DIFF
--- a/lib/tire/search.rb
+++ b/lib/tire/search.rb
@@ -48,7 +48,7 @@ module Tire
       end
 
       def params
-        options = @options.except(:wrapper)
+        options = @options.except(:wrapper, :payload)
         options.empty? ? '' : '?' + options.to_param
       end
 

--- a/test/integration/dsl_search_test.rb
+++ b/test/integration/dsl_search_test.rb
@@ -13,6 +13,7 @@ module Tire
 
         assert_equal 2, s.results.count
         assert_equal 2, s.results.facets['tags']['count']
+        assert_match /_search\?pretty' -d '{/, s.to_curb, 'make sure to ignore payload in param'
       end
 
       should "allow building search query iteratively" do

--- a/test/integration/dsl_search_test.rb
+++ b/test/integration/dsl_search_test.rb
@@ -13,7 +13,7 @@ module Tire
 
         assert_equal 2, s.results.count
         assert_equal 2, s.results.facets['tags']['count']
-        assert_match /_search\?pretty' -d '{/, s.to_curb, 'make sure to ignore payload in param'
+        assert_match /_search\?pretty' -d '{/, s.to_curl, 'make sure to ignore payload in param'
       end
 
       should "allow building search query iteratively" do


### PR DESCRIPTION
When building a Tire.search DSL with a hash of options for the payload, we need to ignore the `:payload` in `params` so the `to_curl` and logging does not include a bunch of noise.

You may want to consider ignoring :payload in these two places too. Thanks!
- https://github.com/karmi/tire/blob/master/lib/tire/count.rb#L26
- https://github.com/karmi/tire/blob/master/lib/tire/multi_search.rb#L181
