### PR TITLE
Allow support of boost (and other options) to Terms Query

### DIFF
--- a/lib/tire/search/query.rb
+++ b/lib/tire/search/query.rb
@@ -20,7 +20,7 @@ module Tire
 
       def terms(field, value, options={})
         @value = { :terms => { field => value } }
-        @value[:terms].update( { :minimum_match => options[:minimum_match] } ) if options[:minimum_match]
+        @value[:terms].update(options)# if options.present?
         @value
       end
 

--- a/lib/tire/search/query.rb
+++ b/lib/tire/search/query.rb
@@ -20,7 +20,7 @@ module Tire
 
       def terms(field, value, options={})
         @value = { :terms => { field => value } }
-        @value[:terms].update(options)# if options.present?
+        @value[:terms].update(options)
         @value
       end
 

--- a/test/unit/search_query_test.rb
+++ b/test/unit/search_query_test.rb
@@ -55,6 +55,11 @@ module Tire::Search
         assert_equal( { :terms => { :foo => ['bar', 'baz'], :minimum_match => 2 } },
                       Query.new.terms(:foo, ['bar', 'baz'], :minimum_match => 2) )
       end
+
+      should "allow set boost when searching for multiple terms" do
+        assert_equal( { :terms => { :foo => ['bar', 'baz'], :boost => 2 } },
+                      Query.new.terms(:foo, ['bar', 'baz'], :boost => 2) )
+      end
     end
 
     context "Range query" do


### PR DESCRIPTION
Hi,

While using tire, I had problem using the boost on query terms.

I am pretty new to both tire and elasticsearch world, so maybe I am just doing it wrong.

With this indices

``` ruby
class User < ActiveRecord::Base
  include Tire::Model::Search
  mapping do
    indexes :comments do
      indexes :id, type: :integer
    end
  end
end
```

A request like : 

``` ruby
search = User.search do
  query do
    boolean do
      should { 
        terms 'comments.id',  [1, 2], boost: 10
      }
    end
  end
end
```

produce such a result : 

```
curl -X GET 'http://localhost:9200/users/user/_search?load=true&size=12&pretty' -d '
  {
    "query": {
      "bool": {
        "should": [
          {
            "terms": {
              "comments.id": [
                1,2
              ]
            }
          }
        ]
      }
    },
    "size": 12
  }
'
```

When I was waiting for something like that : 

```
curl -X GET 'http://localhost:9200/users/user/_search?load=true&size=12&pretty' -d '
  {
    "query": {
      "bool": {
        "should": [
          {
            "terms": {
              "comments.id": [
                1,2
              ],
              "boost": 10
            }
          }
        ]
      }
    },
    "size": 12
  }
'
```

The attached pull request solve that.

Thank you to let me know if it helps or if you need some more informations
