### PR TITLE
Support for constant score query

### DIFF
--- a/lib/tire/search/query.rb
+++ b/lib/tire/search/query.rb
@@ -20,7 +20,7 @@ module Tire
 
       def terms(field, value, options={})
         @value = { :terms => { field => value } }
-        @value[:terms].update(options)
+        @value[:terms].update( { :minimum_match => options[:minimum_match] } ) if options[:minimum_match]
         @value
       end
 

--- a/lib/tire/search/query.rb
+++ b/lib/tire/search/query.rb
@@ -56,6 +56,10 @@ module Tire
         @value
       end
 
+      def constant_score(&block)
+        @value.update( { constant_score: ConstantScoreQuery.new(&block).to_hash } ) if block_given?
+      end
+
       def fuzzy(field, value, options={})
         query = { field => { :term => value }.update(options) }
         @value = { :fuzzy => query }
@@ -113,6 +117,29 @@ module Tire
         to_hash.to_json
       end
 
+    end
+
+    class ConstantScoreQuery
+      def initialize(&block)
+        @value = {}
+        block.arity < 1 ? self.instance_eval(&block) : block.call(self) if block_given?
+      end
+
+      def filter(type, *options)
+        @value.update(filter: Filter.new(type, *options).to_hash)
+      end
+
+      def query(&block)
+        @value.update(query: Query.new(&block).to_hash)
+      end
+
+      def boost(boost)
+        @value.update(boost: boost)
+      end
+
+      def to_hash
+        @value
+      end
     end
 
     class BooleanQuery

--- a/lib/tire/search/query.rb
+++ b/lib/tire/search/query.rb
@@ -20,7 +20,7 @@ module Tire
 
       def terms(field, value, options={})
         @value = { :terms => { field => value } }
-        @value[:terms].update( { :minimum_match => options[:minimum_match] } ) if options[:minimum_match]
+        @value[:terms].update(options)# if options.present?
         @value
       end
 

--- a/lib/tire/search/query.rb
+++ b/lib/tire/search/query.rb
@@ -20,7 +20,7 @@ module Tire
 
       def terms(field, value, options={})
         @value = { :terms => { field => value } }
-        @value[:terms].update(options)# if options.present?
+        @value[:terms].update(options)
         @value
       end
 

--- a/test/integration/constant_score_queries_test.rb
+++ b/test/integration/constant_score_queries_test.rb
@@ -1,0 +1,49 @@
+require 'test_helper'
+
+module Tire
+
+  class ConstantScoreQueriesIntegrationTest < Test::Unit::TestCase
+    include Test::Integration
+    context "Constant score queries" do
+      context 'with filter' do
+        should "return a constant score for all documents even if one document match 'more'" do
+          s = Tire.search('articles-test') do
+            query do
+              constant_score do
+                filter :terms, :tags => ['ruby', 'python']
+              end
+            end
+          end
+
+          assert_equal 2, s.results.size
+          assert_equal ['One', 'Two'], s.results.map(&:title)
+
+          assert s.results[0]._score > 0
+          assert s.results[1]._score > 0
+          assert s.results[0]._score == s.results[1]._score
+        end
+      end
+
+      context 'with query' do
+        should "return a constant score for all documents even if one document match more" do
+          s = Tire.search('articles-test') do
+            query do
+              constant_score do
+                query do
+                  terms :tags, ['ruby', 'python']
+                end
+              end
+            end
+          end
+
+          assert_equal 2, s.results.size
+          assert_equal ['One', 'Two'], s.results.map(&:title)
+
+          assert s.results[0]._score > 0
+          assert s.results[1]._score > 0
+          assert s.results[0]._score == s.results[1]._score
+        end
+      end
+    end
+  end
+end

--- a/test/unit/search_query_test.rb
+++ b/test/unit/search_query_test.rb
@@ -55,6 +55,11 @@ module Tire::Search
         assert_equal( { :terms => { :foo => ['bar', 'baz'], :minimum_match => 2 } },
                       Query.new.terms(:foo, ['bar', 'baz'], :minimum_match => 2) )
       end
+
+      should "allow set boost when searching for multiple terms" do
+        assert_equal( { :terms => { :foo => ['bar', 'baz'], :boost => 2 } },
+                      Query.new.terms(:foo, ['bar', 'baz'], :boost => 2) )
+      end
     end
 
     context "Range query" do

--- a/test/unit/search_query_test.rb
+++ b/test/unit/search_query_test.rb
@@ -420,5 +420,26 @@ module Tire::Search
 
     end
 
+    context 'ConstantScoreQuery' do
+      should "not raise an error when no block is given" do
+        assert_nothing_raised { Query.new.constant_score }
+      end
+
+      should "wrap filter" do
+        assert_equal( { :constant_score => {:filter => { :term => { :attr => 'foo' } } } },
+                      Query.new.constant_score { filter :term, :attr => 'foo' } )
+      end
+
+      should "wrap the boost" do
+        assert_equal( { :constant_score => {:boost => 3 } },
+                      Query.new.constant_score { boost 3 } )
+      end
+
+      should "wrap query" do
+        assert_equal( { :constant_score => {:query => { :term => { :attr => { :term => 'foo' } } } } },
+                      Query.new.constant_score { query { term :attr, 'foo' } } )
+      end
+    end
+
   end
 end

--- a/test/unit/search_query_test.rb
+++ b/test/unit/search_query_test.rb
@@ -55,11 +55,6 @@ module Tire::Search
         assert_equal( { :terms => { :foo => ['bar', 'baz'], :minimum_match => 2 } },
                       Query.new.terms(:foo, ['bar', 'baz'], :minimum_match => 2) )
       end
-
-      should "allow set boost when searching for multiple terms" do
-        assert_equal( { :terms => { :foo => ['bar', 'baz'], :boost => 2 } },
-                      Query.new.terms(:foo, ['bar', 'baz'], :boost => 2) )
-      end
     end
 
     context "Range query" do


### PR DESCRIPTION
Hi,
I did not see support to [constant_score queries](http://www.elasticsearch.org/guide/reference/query-dsl/constant-score-query.html) in tire code.
Here is my pull request with the support of it.

I hope it helps !
