### PR TITLE
Improve the `tire:import` Rake task

### DIFF
--- a/lib/tire/model/import.rb
+++ b/lib/tire/model/import.rb
@@ -16,7 +16,14 @@ module Tire
         def import options={}, &block
           options = { :method => 'paginate' }.update options
           index   = options[:index] ? Tire::Index.new(options.delete(:index)) : self.index
-          index.import klass, options, &block
+          if klass.respond_to? :find_in_batches
+            klass.tire.index_scope.find_in_batches do |group|
+              index.import group, options, &block
+              GC.start
+            end
+          else
+            index.import klass.index_scope, options, &block
+          end
         end
 
       end

--- a/lib/tire/model/indexing.rb
+++ b/lib/tire/model/indexing.rb
@@ -27,6 +27,28 @@ module Tire
           yield if block_given?
         end
 
+        # Define the _index_scope_ for the corresponding model, telling tire how to look at the model for
+        # indexing its contents.
+        #
+        # Usage:
+        #
+        #     class Article
+        #       # ...
+        #       index_scope do
+        #         includes(:comments)
+        #       end
+        #     end
+        #
+
+        def index_scope(&block)
+          @index_scope ||= proc { self }
+          if block_given?
+            @index_scope = block
+          else
+            klass.class_eval(&@index_scope)
+          end
+        end
+
         # Define the [_mapping_](http://www.elasticsearch.org/guide/reference/mapping/index.html)
         # for the corresponding index, telling _Elasticsearch_ how to understand your documents:
         # what type is which property, whether it is analyzed or no, which analyzer to use, etc.

--- a/lib/tire/model/search.rb
+++ b/lib/tire/model/search.rb
@@ -1,3 +1,5 @@
+require 'set'
+
 module Tire
   module Model
 
@@ -18,6 +20,9 @@ module Tire
     #
     #
     module Search
+
+      mattr_accessor :dependents
+      self.dependents = Set.new
 
       # Alias for Tire::Model::Naming::ClassMethods.index_prefix
       #
@@ -254,6 +259,7 @@ module Tire
       # A hook triggered by the `include Tire::Model::Search` statement in the model.
       #
       def self.included(base)
+        self.dependents << base
         base.class_eval do
 
           # Returns proxy to the _Tire's_ class methods.

--- a/lib/tire/tasks.rb
+++ b/lib/tire/tasks.rb
@@ -121,10 +121,10 @@ namespace :tire do
     full_comment_drop = <<-DESC.gsub(/      /, '')
       Delete indices passed in the INDEX environment variable; separate multiple indices by comma.
 
-      Pass name of a single index to drop in the INDEX environmnet variable:
+      Pass name of a single index to drop in the INDEX environment variable:
         $ rake environment tire:index:drop INDEX=articles
 
-      Pass names of multiple indices to drop in the INDEX or INDICES environmnet variable:
+      Pass names of multiple indices to drop in the INDEX or INDICES environment variable:
         $ rake environment tire:index:drop INDICES=articles-2011-01,articles-2011-02
 
     DESC

--- a/lib/tire/tasks.rb
+++ b/lib/tire/tasks.rb
@@ -72,7 +72,8 @@ namespace :tire do
       # Create the index if it doesn't exist
       unless index.exists?
         mapping = MultiJson.encode(klass.tire.mapping_to_hash, :pretty => Tire::Configuration.pretty)
-        puts "[IMPORT] Creating index '#{index.name}' with mapping:", mapping
+        puts "[IMPORT] Creating index '#{index.name}' with mapping:",
+             mapping
         unless index.create(:mappings => klass.tire.mapping_to_hash, :settings => klass.tire.settings)
           STDERR.puts "[ERROR] There has been an error when creating the index -- elasticsearch returned:",
                       index.response

--- a/lib/tire/tasks.rb
+++ b/lib/tire/tasks.rb
@@ -1,105 +1,115 @@
 require 'rake'
-require 'benchmark'
+require 'progress_bar'
+require 'set'
 
 namespace :tire do
 
   full_comment_import = <<-DESC.gsub(/    /, '')
     Import data from your model using paginate: rake environment tire:import CLASS='MyModel'.
 
-    Pass params for the `paginate` method:
-      $ rake environment tire:import CLASS='Article' PARAMS='{:page => 1}'
+    import all models:
+      $ rake tire:import
 
     Force rebuilding the index (delete and create):
-      $ rake environment tire:import CLASS='Article' PARAMS='{:page => 1}' FORCE=1
+      $ rake tire:import FORCE=1
 
-    Set target index name:
-      $ rake environment tire:import CLASS='Article' INDEX='articles-new'
+    Set target classes:
+      $ rake tire:import CLASS='Article, Comment'
   DESC
   desc full_comment_import
-  task :import do |t|
-
-    def elapsed_to_human(elapsed)
-      hour = 60*60
-      day  = hour*24
-
-      case elapsed
-      when 0..59
-        "#{sprintf("%1.2f", elapsed)} seconds"
-      when 60..hour-1
-        "#{(elapsed/60).floor} minutes and #{(elapsed % 60).floor} seconds"
-      when hour..day
-        "#{(elapsed/hour).floor} hours and #{(elapsed/60 % hour).floor} minutes"
-      else
-        "#{(elapsed/hour).round} hours"
-      end
-    end
-
-    if ENV['CLASS'].to_s == ''
-      puts '='*90, 'USAGE', '='*90, full_comment_import, ""
-      exit(1)
-    end
-
-    klass  = eval(ENV['CLASS'].to_s)
-    params = eval(ENV['PARAMS'].to_s) || {}
-
-    params.update :method => 'paginate'
-
-    index = Tire::Index.new( ENV['INDEX'] || klass.tire.index.name )
-
-    if ENV['FORCE']
-      puts "[IMPORT] Deleting index '#{index.name}'"
-      index.delete
-    end
-
-    unless index.exists?
-      mapping = MultiJson.encode(klass.tire.mapping_to_hash, :pretty => Tire::Configuration.pretty)
-      puts "[IMPORT] Creating index '#{index.name}' with mapping:", mapping
-      unless index.create( :mappings => klass.tire.mapping_to_hash, :settings => klass.tire.settings )
-        STDERR.puts "[ERROR] There has been an error when creating the index -- elasticsearch returned:",
-                    index.response
-        exit(1)
-      end
-    end
+  task :import => :environment do
 
     STDOUT.sync = true
-    puts "[IMPORT] Starting import for the '#{ENV['CLASS']}' class"
-    tty_cols = 80
-    total    = klass.count rescue nil
-    offset   = (total.to_s.size*2)+8
-    done     = 0
+    TIRE_MODELS = Set.new
+    HRULE       = '='*90
 
-    STDOUT.puts '-'*tty_cols
-    elapsed = Benchmark.realtime do
+    if ENV['CLASS'].to_s != ''
+      # Use Models in the ENV Vars
+      TIRE_MODELS += ENV['CLASS'].split(',').map { |k| eval k }
 
-      # Add Kaminari-powered "paginate" method
-      #
-      if defined?(Kaminari) && klass.respond_to?(:page)
-        klass.instance_eval do
-          def paginate(options = {})
-            page(options[:page]).per(options[:per_page]).to_a
-          end
+    else
+      # Find all the classes which call mapping
+      puts "\n", "[IMPORT] Preloading Models..."
+      Tire::Model::Search::ClassMethods.module_eval do
+        def mapping(*args, &block)
+          TIRE_MODELS << self.klass
+          super(*args, &block)
         end
-      end unless klass.respond_to?(:paginate)
+      end
 
-      # Import the documents
-      #
-      index.import(klass, params) do |documents|
+      # Require everything in the models directory
+      Dir.glob(Rails.root.join('app/models/**/*.rb')).each { |path| require path }
+    end
 
-        if total
-          done += documents.to_a.size
-          # I CAN HAZ PROGREZ BAR LIEK HOMEBRU!
-          percent  = ( (done.to_f / total) * 100 ).to_i
-          glyphs   = ( percent * ( (tty_cols-offset).to_f/100 ) ).to_i
-          STDOUT.print( "#" * glyphs )
-          STDOUT.print( "\r"*tty_cols+"#{done}/#{total} | \e[1m#{percent}%\e[0m " )
-        end
+    # exit(1) if no models are found!
+    puts HRULE, 'USAGE', HRULE, full_comment_import, "" and exit(1) unless TIRE_MODELS.size > 0
 
-        # Don't forget to return the documents collection back!
-        documents
+    # Import Methods
+    TOTAL_COUNT = TIRE_MODELS.map(&:count).reduce(&:+)
+
+    def params
+      @params ||= begin
+        params = eval(ENV['PARAMS'].to_s) || {}
+        params.update :method => 'paginate'
       end
     end
 
-    puts "", '='*80, "Import finished in #{elapsed_to_human(elapsed)}"
+    TIRE_MODELS.each do |klass|
+
+      puts "\n\n"
+
+      index = klass.tire.index
+
+      # Force delete the index
+      if ENV['FORCE']
+        puts "[IMPORT] Deleting index '#{index.name}'"
+        index.delete
+      end
+
+      # Create the index if it doesn't exist
+      unless index.exists?
+        mapping = MultiJson.encode(klass.tire.mapping_to_hash, :pretty => Tire::Configuration.pretty)
+        puts "[IMPORT] Creating index '#{index.name}' with mapping:", mapping
+        unless index.create(:mappings => klass.tire.mapping_to_hash, :settings => klass.tire.settings)
+          STDERR.puts "[ERROR] There has been an error when creating the index -- elasticsearch returned:",
+                      index.response
+          exit(1)
+        end
+      end
+
+      puts "[IMPORT] Starting import for the '#{klass}' class"
+      progress_bar = ProgressBar.new(klass.count)
+
+      # Use an indexer scope if it is defined
+      klass = klass.indexer if klass.respond_to? :indexer
+
+      # Try and use AR find_in_batches
+      if klass.respond_to?(:find_in_batches)
+        klass.find_in_batches do |group|
+          index.import(group, params) do |documents|
+            GC.start
+            progress_bar.increment! documents.count
+            documents
+          end
+        end
+      elsif klass.respond_to? :all
+        index.import(klass.all, params) do |documents|
+          GC.start
+          progress_bar.increment! documents.count
+          documents
+        end
+      else
+        index.import(klass, params) do |documents|
+          GC.start
+          progress_bar.increment! documents.count
+          documents
+        end
+      end
+
+    end
+
+    puts '[DONE]'
+
   end
 
   namespace :index do
@@ -126,7 +136,7 @@ namespace :tire do
       index_names.each do |name|
         index = Tire::Index.new(name)
         print "* Deleting index \e[1m#{index.name}\e[0m... "
-        puts  index.delete ? "\e[32mOK\e[0m" : "\e[31mFAILED\e[0m  | #{index.response.body}"
+        puts index.delete ? "\e[32mOK\e[0m" : "\e[31mFAILED\e[0m  | #{index.response.body}"
       end
 
       puts ""

--- a/lib/tire/tasks.rb
+++ b/lib/tire/tasks.rb
@@ -21,7 +21,6 @@ namespace :tire do
 
   DESC
   desc full_comment_import
-  task :import => :environment do
 
     STDOUT.sync = true
     TIRE_MODELS = Set.new

--- a/lib/tire/tasks.rb
+++ b/lib/tire/tasks.rb
@@ -60,9 +60,8 @@ namespace :tire do
 
     TIRE_MODELS.each do |klass|
 
-      puts "\n\n"
-
-      index = klass.tire.index
+      # Set the Index
+      index = ENV['INDEX'].to_s != '' ? Tire::Index.new(ENV['INDEX']) : klass.tire.index
 
       # Force delete the index
       if ENV['FORCE']

--- a/lib/tire/tasks.rb
+++ b/lib/tire/tasks.rb
@@ -1,5 +1,5 @@
 require 'rake'
-require 'progress_bar'
+require 'ansi/progressbar'
 require 'set'
 
 namespace :tire do

--- a/lib/tire/tasks.rb
+++ b/lib/tire/tasks.rb
@@ -21,6 +21,12 @@ namespace :tire do
 
   DESC
   desc full_comment_import
+  task :import do
+
+    if defined?(Rails)
+      puts "[IMPORT] Rails detected, booting environment..."
+      Rake::Task["environment"].invoke
+    end
 
     STDOUT.sync = true
     TIRE_MODELS = Set.new

--- a/tire.gemspec
+++ b/tire.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
   s.add_dependency "multi_json",  "~> 1.3"
   s.add_dependency "activemodel", ">= 3.0"
   s.add_dependency "hashr",       "~> 0.0.19"
+  s.add_dependency "progress_bar", "~> 0.4.0"
 
   # = Development dependencies
   #

--- a/tire.gemspec
+++ b/tire.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_dependency "multi_json",  "~> 1.3"
   s.add_dependency "activemodel", ">= 3.0"
   s.add_dependency "hashr",       "~> 0.0.19"
-  s.add_dependency "progress_bar", "~> 0.4.0"
+  s.add_dependency "ansi"
 
   # = Development dependencies
   #


### PR DESCRIPTION
I wanted to submit this as a topic for conversation. This solution provides the following:
- Detection of models using Tire::Model::Search.mapping, auto-indexes all of these by default.
- You can still pass CLASS var, but it now accepts multiples.
- Removed Kaminari, not sure why it was needed in this task.
- Uses the progress_bar gem, a very clean implementation IMHO.
