### PR TITLE
Remove the to_a; fixes data_mapper n+1 queries

### DIFF
--- a/lib/tire/tasks.rb
+++ b/lib/tire/tasks.rb
@@ -76,7 +76,7 @@ namespace :tire do
       if defined?(Kaminari) && klass.respond_to?(:page)
         klass.instance_eval do
           def paginate(options = {})
-            page(options[:page]).per(options[:per_page]).to_a
+            page(options[:page]).per(options[:per_page])
           end
         end
       end unless klass.respond_to?(:paginate)


### PR DESCRIPTION
When using Kaminari, whatever is returned from the scopes will behave as an array.

In the case of data_mapper this is especially important, because what gets returned also handles eager loading records. With the to_a in place, it's very likely that an n+1 query will be created during import.
