### PR TITLE
Fix memory leaks on large imports

### DIFF
--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -246,11 +246,12 @@ module Tire
         when method = options.delete(:method)
           options = {:page => 1, :per_page => 1000}.merge options
           while documents = klass_or_collection.send(method.to_sym, options.merge(:page => options[:page])) \
-                            and documents.to_a.length > 0
+                            && documents.to_a.length > 0
 
             documents = yield documents if block_given?
 
             bulk_store documents, options
+            GC.start
             options[:page] += 1
           end
 

--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -245,7 +245,7 @@ module Tire
       case
         when method = options.delete(:method)
           options = {:page => 1, :per_page => 1000}.merge options
-          while documents = klass_or_collection.send(method.to_sym, options.merge(:page => options[:page])) \
+          while (documents = klass_or_collection.send(method.to_sym, options.merge(:page => options[:page]))) \
                             && documents.to_a.length > 0
 
             documents = yield documents if block_given?


### PR DESCRIPTION
GC.start after consecutive batch imports causes a memory leak. While importing 6 million records, the stack grew from 200mb to ~5GB. This fixes that issue.
