### PR TITLE
change #find to #find_by_ids

### DIFF
--- a/lib/tire/results/collection.rb
+++ b/lib/tire/results/collection.rb
@@ -148,7 +148,7 @@ module Tire
       end
 
       def __find_records_by_ids(klass, ids)
-        @options[:load] === true ? klass.find(ids) : klass.find(ids, @options[:load])
+        @options[:load] === true ? klass.find_by_id(ids) : klass.find_by_id(ids, @options[:load])
       end
     end
 


### PR DESCRIPTION
Use find_by_ids when loading the collection. If a record was deleted, but ES has not been updated yet, #find would throw a ActiveRecord::RecordNotFound exception.
# find_by_ids returns only the records that are available
