### PR TITLE
Fix Alias.all

### DIFF
--- a/lib/tire/alias.rb
+++ b/lib/tire/alias.rb
@@ -94,7 +94,7 @@ module Tire
 
       aliases = MultiJson.decode(@response.body).inject({}) do |result, (index, value)|
         # 1] Skip indices without aliases
-        next result if value['aliases'].empty?
+        next result if !value['aliases'] || value['aliases'].empty?
 
         # 2] Build a reverse map of hashes (alias => indices, config)
         value['aliases'].each do |key, value| (result[key] ||= { 'indices' => [] }).update(value)['indices'].push(index) end


### PR DESCRIPTION
Hi,
I open this PR to fix a check in alias.rb at line 97. This fix avoid raising of "NoMethodError: undefined method `empty?' for nil:NilClass" when the key 'aliases' is not present in value hash.

I add the fix because I am receiving that error when I call: Tire.index(index).aliases

NoMethodError: undefined method `empty?' for nil:NilClass

[GEM_ROOT]/gems/tire-0.5.5/lib/tire/alias.rb:97:in `block in all'
[GEM_ROOT]/gems/tire-0.5.5/lib/tire/alias.rb:95:in`each'
[GEM_ROOT]/gems/tire-0.5.5/lib/tire/alias.rb:95:in `inject'
[GEM_ROOT]/gems/tire-0.5.5/lib/tire/alias.rb:95:in`all'
[GEM_ROOT]/gems/tire-0.5.5/lib/tire/index.rb:52:in `aliases'
...

Unfortunately I was unable to add a test to cover this behaviour: I tried to change index_alias_test and index_test without success.
