### PR TITLE
using find_all_by_id to prevent record not found errors when there is a missing record. 

### DIFF
--- a/lib/tire/results/collection.rb
+++ b/lib/tire/results/collection.rb
@@ -148,7 +148,7 @@ module Tire
       end
 
       def __find_records_by_ids(klass, ids)
-        @options[:load] === true ? klass.find(ids) : klass.find(ids, @options[:load])
+        @options[:load] === true ? klass.find_all_by_id(ids) : klass.find_all_by_id(ids, @options[:load])
       end
     end
 

--- a/lib/tire/search/query.rb
+++ b/lib/tire/search/query.rb
@@ -19,7 +19,7 @@ module Tire
       end
 
       def terms(field, value, options={})
-        @value = { :terms => { field => value } }
+        @value = { :terms => { field => Array(value) } }
         @value[:terms].update( { :minimum_match => options[:minimum_match] } ) if options[:minimum_match]
         @value
       end


### PR DESCRIPTION
Using find_all_by_id to prevent record not found errors when there is a missing record.
Always returns an array even if there is a single object to find.
