### PR TITLE
Allow for specifying version in Tire::Index#store

### DIFF
--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -135,6 +135,7 @@ module Tire
       params[:parent]  = options[:parent]  if options[:parent]
       params[:routing] = options[:routing] if options[:routing]
       params[:replication] = options[:replication] if options[:replication]
+      params[:version] = options[:version] if options[:version]
 
       params_encoded = params.empty? ? '' : "?#{params.to_param}"
 


### PR DESCRIPTION
Allow for the version param as specified here http://www.elasticsearch.org/guide/reference/api/index_/
