### PR TITLE
added read_attribute_for_serialization to result item

### DIFF
--- a/lib/tire/results/item.rb
+++ b/lib/tire/results/item.rb
@@ -34,6 +34,10 @@ module Tire
         @attributes[key.to_sym]
       end
 
+      def read_attribute_for_serialization(key)
+        @attributes[key.to_sym]
+      end
+
       def id
         @attributes[:_id]   || @attributes[:id]
       end

--- a/lib/tire/results/item.rb
+++ b/lib/tire/results/item.rb
@@ -33,10 +33,9 @@ module Tire
       def [](key)
         @attributes[key.to_sym]
       end
+      
+      alias :read_attribute_for_serialization :[]
 
-      def read_attribute_for_serialization(key)
-        @attributes[key.to_sym]
-      end
 
       def id
         @attributes[:_id]   || @attributes[:id]

--- a/test/unit/results_item_test.rb
+++ b/test/unit/results_item_test.rb
@@ -60,6 +60,15 @@ module Tire
         assert_equal 'Kafka', @document[:author][:name]
       end
 
+      should "retrieve simple values from read_attribute_for_serialization" do
+        assert_equal 'Test', @document.read_attribute_for_serialization(:title)
+      end
+
+      should "retrieve hash values from read_attribute_for_serialization" do
+        assert_equal 'Kafka', @document.read_attribute_for_serialization(:author)[:name]
+      end
+
+
       should "allow to retrieve value by methods" do
         assert_not_nil @document.title
         assert_equal 'Test', @document.title


### PR DESCRIPTION
I added the method **read_attribute_for_serialization** to the result item to support active model serializers.
