### PR TITLE
Add support for geo distance facets

### DIFF
--- a/lib/tire/search/facet.rb
+++ b/lib/tire/search/facet.rb
@@ -2,7 +2,7 @@ module Tire
   module Search
 
     #--
-    # TODO: Implement all elastic search facets (geo, histogram, range, etc)
+    # TODO: Implement remaining elastic search facets (date histogram)
     # http://elasticsearch.org/guide/reference/api/search/facets/
     #++
 
@@ -45,6 +45,11 @@ module Tire
 
       def statistical(field, options={})
         @value[:statistical] = (options.delete(:statistical) || {:field => field}.update(options))
+        self
+      end
+
+      def geo_distance(field, point, ranges=[], options={})
+        @value[:geo_distance] = { field => point, :ranges => ranges }.update(options)
         self
       end
 

--- a/test/integration/facets_test.rb
+++ b/test/integration/facets_test.rb
@@ -194,6 +194,50 @@ module Tire
 
       end
 
+      context "geo distance" do
+        setup do
+          @index = Tire.index('bars-test') do
+            delete
+            create :mappings => {
+                     :bar => {
+                       :properties => {
+                         :name =>     { :type => 'string' },
+                         :location => { :type => 'geo_point', :lat_lon => true }
+                       }
+                     }
+                   }
+
+            store :type => 'bar',
+                  :name => 'one',
+                  :location => {:lat => 53.54412, :lon => 9.94021}
+            store :type => 'bar',
+                  :name => 'two',
+                  :location => {:lat => 53.54421, :lon => 9.94673}
+            store :type => 'bar',
+                  :name => 'three',
+                  :location => {:lat => 53.55099, :lon => 10.02527}
+            refresh
+          end
+        end
+
+        teardown { @index.delete }
+
+        should "return aggregated values for all results" do
+          s = Tire.search('bars-test') do
+            query { all }
+            facet 'geo' do
+              geo_distance :location, {:lat => 53.54507, :lon => 9.95309}, [{:to => 1}, {:from => 1, :to => 10}, {:from => 50}], unit: 'km'
+            end
+          end
+
+          facets = s.results.facets['geo']['ranges']
+          assert_equal 3, facets.size, facets.inspect
+          assert_equal 2, facets.entries[0]['total_count'], facets.inspect
+          assert_equal 1, facets.entries[1]['total_count'], facets.inspect
+          assert_equal 0, facets.entries[2]['total_count'], facets.inspect
+        end
+      end
+
       context "statistical" do
 
         should "return computed statistical data on a numeric field" do

--- a/test/unit/search_facet_test.rb
+++ b/test/unit/search_facet_test.rb
@@ -168,6 +168,21 @@ module Tire::Search
         end
       end
 
+      context "geo_distance facet" do
+        should "encode facet options" do
+          f = Facet.new('geo_distance') { geo_distance :location, {:lat => 50, :lon => 9}, [{:to => 1}] }
+          assert_equal({:geo_distance => {:geo_distance => {:location => {:lat => 50, :lon => 9}, :ranges => [{:to => 1}]}}}.to_json,
+                       f.to_json)
+        end
+
+        should "encode custom options" do
+          f = Facet.new('geo_distance') { geo_distance :location, {:lat => 50, :lon => 9}, [{:to => 1}],
+                                                       :unit => 'km', :value_script => 'doc["field"].value'}
+          assert_equal({:geo_distance => {:geo_distance => {:location => {:lat => 50, :lon => 9}, :ranges => [{:to => 1}],
+                                                            :unit => "km", :value_script => 'doc["field"].value'}}}.to_json, f.to_json)
+        end
+      end
+
       context "filter facet" do
 
         should "encode facet options" do


### PR DESCRIPTION
This pull request adds implementation and tests for geo distance facets to tire, see http://www.elasticsearch.org/guide/reference/api/search/facets/geo-distance-facet for more details.

Thanks for your work on tire. We use it at Stuffle (http://stuffle.it) and it's great how little effort was needed to integrate ElasticSearch.

Cheers,
Robin
