### PR TITLE
Add 'strategy' option to bulk import

### DIFF
--- a/lib/tire/model/import.rb
+++ b/lib/tire/model/import.rb
@@ -26,6 +26,9 @@ module Tire
       #
       module Strategy
         def self.from_class(klass, options={})
+          if options[:strategy]
+            return const_get(options[:strategy]).new(klass, options)
+          end
           case
           when defined?(::ActiveRecord) && klass.ancestors.include?(::ActiveRecord::Base)
             ActiveRecord.new klass, options

--- a/lib/tire/model/import.rb
+++ b/lib/tire/model/import.rb
@@ -26,9 +26,7 @@ module Tire
       #
       module Strategy
         def self.from_class(klass, options={})
-          if options[:strategy]
-            return const_get(options[:strategy]).new(klass, options)
-          end
+          return const_get(options[:strategy]).new(klass, options) if options[:strategy]
           case
           when defined?(::ActiveRecord) && klass.ancestors.include?(::ActiveRecord::Base)
             ActiveRecord.new klass, options

--- a/test/unit/model_import_test.rb
+++ b/test/unit/model_import_test.rb
@@ -21,6 +21,10 @@ class ImportModel
   end
 end
 
+class CustomImportStrategy
+  include Tire::Model::Import::Strategy::Base
+end
+
 module Tire
   module Model
 
@@ -65,6 +69,20 @@ module Tire
         should "store the documents in a different index" do
           Tire::Index.expects(:new).with('new_index').returns( mock('index') { expects(:import) } )
           ImportModel.import :index => 'new_index'
+        end
+
+        context 'Strategy' do
+
+          should 'return explicitly specified strategy from predefined strategies' do
+            strategy = Tire::Model::Import::Strategy.from_class(ImportModel, :strategy => 'WillPaginate')
+            assert_equal strategy.class.name, 'Tire::Model::Import::Strategy::WillPaginate'
+          end
+
+          should 'return custom strategy class' do
+            strategy = Tire::Model::Import::Strategy.from_class(ImportModel, :strategy => 'CustomImportStrategy')
+            assert_equal strategy.class.name, 'CustomImportStrategy'
+          end
+
         end
 
       end


### PR DESCRIPTION
During bulk import for active_record models sometimes it is important to eager load associations, which can't be done with default strategy for active_record models.
