### PR TITLE
Make Tire::Results::Collection.to_ary return an array

### DIFF
--- a/lib/tire/results/collection.rb
+++ b/lib/tire/results/collection.rb
@@ -58,7 +58,7 @@ module Tire
       alias :[] :slice
 
       def to_ary
-        self
+        results
       end
 
       def as_json(options=nil)

--- a/test/unit/results_collection_test.rb
+++ b/test/unit/results_collection_test.rb
@@ -79,6 +79,13 @@ module Tire
         assert_equal 1.0, collection.max_score
       end
 
+      should "return a Ruby array" do
+        collection = Results::Collection.new(@default_response)
+        to_ary_result = collection.to_ary
+        array = Array.new
+        assert to_ary_result.is_a? array
+      end
+
       context "serialization" do
 
         should "be serialized to JSON" do


### PR DESCRIPTION
This commit fixes the fact that calling to_ary() on a Tire::Results::Collection object returns another Tire::Results::Collection object... which is not an array.
