### PR TITLE
Fix incomplete nested to_hash functionality

### DIFF
--- a/lib/tire/results/item.rb
+++ b/lib/tire/results/item.rb
@@ -60,7 +60,11 @@ module Tire
 
       def to_hash
         @attributes.reduce({}) do |sum, item|
-          sum[ item.first ] = item.last.respond_to?(:to_hash) ? item.last.to_hash : item.last
+          if item.last.is_a?(Array)
+            sum[ item.first ] = item.last.map { |item| item.respond_to?(:to_hash) ? item.to_hash : item }
+          else
+            sum[ item.first ] = item.last.respond_to?(:to_hash) ? item.last.to_hash : item.last
+          end
           sum
         end
       end

--- a/test/unit/results_item_test.rb
+++ b/test/unit/results_item_test.rb
@@ -15,9 +15,12 @@ module Tire
     context "Item" do
 
       setup do
-        @document = Results::Item.new :title  => 'Test',
-                                      :author => { :name => 'Kafka' },
-                                      :awards => { :best_fiction => { :year => '1925' } }
+        @document = Results::Item.new :title   => 'Test',
+                                      :author  => { :name => 'Kafka' },
+                                      :awards  => { :best_fiction => { :year => '1925' } },
+                                      :reviews => [ { :stars => 5, :comment => 'great' },
+                                                    { :stars => 3, :comment => 'decent' } ]
+                                                     
       end
 
       should "be initialized with a Hash or Hash like object" do
@@ -115,6 +118,8 @@ module Tire
         assert_instance_of Hash, @document.to_hash
         assert_instance_of Hash, @document.to_hash[:author]
         assert_instance_of Hash, @document.to_hash[:awards][:best_fiction]
+        assert_instance_of Hash, @document.to_hash[:reviews][0]
+        assert_instance_of Hash, @document.to_hash[:reviews][1]
 
         assert_equal 'Kafka', @document.to_hash[:author][:name]
         assert_equal '1925',  @document.to_hash[:awards][:best_fiction][:year]


### PR DESCRIPTION
Issue #339 addressed the lacking functionality for the `to_hash` to work in a recursive fashion. This was fixed, however, I noticed it does not work if `Tire::Results::Item` contains an array with `Tire::Results::Item` objects. In this case the array is just skipped.

```
<Item title:   "Test", author: <Item name: "Kafka">,
      awards:  <Item best_fiction: <Item year: "1925">>,
      reviews: [<Item stars: 5, comment: "great">,
                <Item stars: 3, comment: "decent">]
```

becomes

```
{:title =>   "Test", :author => {:name => "Kafka"},
 :awards =>  {:best_fiction => {:year => "1925"}},
 :reviews => [<Item stars: 5, comment: "great">,
              <Item stars: 3, comment: "decent">]}
```

and not as expected

```
{:title   => "Test", :author => {:name => "Kafka"},
 :awards  => {:best_fiction => {:year => "1925"}},
 :reviews => [{:stars => 5, :comment => "great"},
              {:stars => 3, :comment => "decent"}]}
```

I have extended the unit test case to reveal this problem and added a fix. I hope this helps, at least I need this, as I was expecting this behavior. I am also curious if there is an alternative, more elegant, implementation to my solution.
