### PR TITLE
Import task for Mongoid models should use the cursor, rather than skip()

### DIFF
--- a/lib/tire/model/import.rb
+++ b/lib/tire/model/import.rb
@@ -62,9 +62,13 @@ module Tire
         class Mongoid
           include Base
           def import &block
-            0.step(klass.count, options[:per_page]) do |offset|
-              items = klass.limit(options[:per_page]).skip(offset)
-              index.import items.to_a, options, &block
+            items = []
+            klass.all.each do |item|
+              items << item
+              if items.length >= options[:per_page]
+                index.import items, options, &block
+                items = []
+              end
             end
             self
           end


### PR DESCRIPTION
Iterating through mongoid collections using skip() can get really slow for large collections, as it has to traverse from the beginning of the collection.
http://docs.mongodb.org/manual/reference/method/cursor.skip/

We were seeing our import task freeze up with high I/O after importing around 2.5 million records in a 6 million record collection.

This commit alters the mongoid import task so that it batches manually and makes the use of mongoid's cursor to only return a small batch of results.
