### PR TITLE
Fix the issue with a single object vs array being returned

### DIFF
--- a/lib/tire/results/collection.rb
+++ b/lib/tire/results/collection.rb
@@ -136,7 +136,7 @@ module Tire
                              "based on _type '#{type}'.", e.backtrace
           end
 
-          records[type] = __find_records_by_ids klass, items.map { |h| h['_id'] }
+          records[type] = [*(__find_records_by_ids klass, items.map { |h| h['_id'] })]
         end
 
         # Reorder records to preserve the order from search results

--- a/lib/tire/results/collection.rb
+++ b/lib/tire/results/collection.rb
@@ -136,7 +136,7 @@ module Tire
                              "based on _type '#{type}'.", e.backtrace
           end
 
-          records[type] = [*(__find_records_by_ids klass, items.map { |h| h['_id'] })]
+          records[type] = Array(__find_records_by_ids klass, items.map { |h| h['_id'] })
         end
 
         # Reorder records to preserve the order from search results

--- a/test/integration/active_model_searchable_test.rb
+++ b/test/integration/active_model_searchable_test.rb
@@ -69,7 +69,7 @@ module Tire
 
         a.index.refresh
         results = SupermodelArticle.search 'test'
-        
+
         assert_equal 0, results.count
       end
 
@@ -103,6 +103,18 @@ module Tire
           assert_instance_of SupermodelArticle, results.first.load
 
           assert_equal 'Test', results.first.load.title
+        end
+
+        should "autoload the underlying model" do
+          a = SupermodelArticle.new :title => 'Test'
+          a.save
+          a.index.refresh
+
+          results = SupermodelArticle.search 'test', load: true
+
+          assert_instance_of SupermodelArticle, results.first
+
+          assert_equal 'Test', results.first.title
         end
 
       end

--- a/test/integration/persistent_model_test.rb
+++ b/test/integration/persistent_model_test.rb
@@ -44,6 +44,14 @@ module Tire
         assert_instance_of PersistentArticle, results.first
       end
 
+      should "return real instances of model" do
+        PersistentArticle.create :id => 1, :title => 'One'
+        PersistentArticle.index.refresh
+
+        results = PersistentArticle.search 'one', load: true
+        assert_instance_of PersistentArticle, results.first
+      end
+
       should "save documents into index and find them by IDs" do
         one = PersistentArticle.create :id => 1, :title => 'One'
         two = PersistentArticle.create :id => 2, :title => 'Two'


### PR DESCRIPTION
If you use load: true when the search would return a single object it raises the error
NoMethodError:
       undefined method `detect' for #<--elastic search persistance model-->

This has been fixed before but it must have been lost when the code was refactored.
See https://github.com/karmi/tire/pull/353

Original issue:
http://stackoverflow.com/questions/10592005/tire-gem-undefined-method-detect
