### PR TITLE
support custom filters score

### DIFF
--- a/lib/tire/search/query.rb
+++ b/lib/tire/search/query.rb
@@ -109,6 +109,13 @@ module Tire
         @value
       end
 
+      def custom_filters_score(options={}, &block)
+        @custom_filters ||= CustomFiltersScoreQuery.new(options)
+        block.arity < 1 ? @custom_filters.instance_eval(&block) : block.call(@custom_filters) if block_given?
+        @value[:custom_filters_score] = @custom_filters.to_hash
+        @value
+      end
+
       def to_hash
         @value
       end
@@ -273,5 +280,26 @@ module Tire
       end
     end
 
+    class CustomFiltersScoreQuery
+      def initialize(options={},&block)
+        @value = options
+        block.arity < 1 ? self.instance_eval(&block) : block.call(self) if block_given?
+      end
+
+      def query(options={}, &block)
+        @value[:query] = Query.new(&block).to_hash
+        @value
+      end
+
+      def filter(filter_options, type, *options)
+        @value[:filters] ||= []
+        @value[:filters] << {:filter => Filter.new(type, *options).to_hash}.merge(filter_options)
+        @value
+      end
+    
+      def to_hash
+        @value
+      end
+    end
   end
 end

--- a/test/integration/custom_filters_score_queries_test.rb
+++ b/test/integration/custom_filters_score_queries_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+module Tire
+
+  class CustomFiltersScoreQueriesIntegrationTest < Test::Unit::TestCase
+    include Test::Integration
+
+    context "Custom filters score queries" do
+
+      should "allow boosting score based on filters" do
+        s = Tire.search('articles-test') do
+          query do
+            # Give documents over 300 words hight scores
+            custom_filters_score do
+              query do
+                constant_score do
+                  query { all}
+                  boost 1
+                end
+              end
+              filter({:boost => 3}, :range, :words => {:gt => 300})
+            end
+          end
+        end
+
+        assert_equal 3, s.results[0]._score
+        assert_equal 1, s.results[1]._score
+      end
+    end
+  end
+
+end

--- a/test/unit/search_query_test.rb
+++ b/test/unit/search_query_test.rb
@@ -442,5 +442,33 @@ module Tire::Search
 
     end
 
+    context 'CustomFiltersScoreQuery' do
+      should "encode options" do
+        query = Query.new.custom_filters_score(:score_mode => 'multiply', :max_boost => 2.0) do
+          query { string 'foo' }
+        end
+        assert_equal 'multiply', query[:custom_filters_score][:score_mode]
+        assert_equal 2.0, query[:custom_filters_score][:max_boost]
+      end
+
+      should "wrap single query with filters" do
+        query = Query.new.custom_filters_score do
+          query { string 'foo' } 
+          filter({:boost => 2}, :term, :attr => 'foo')
+          filter({:boost => 3}, :term, :attr => 'bar')
+        end
+        assert_equal( { :custom_filters_score => {
+                          :query => {:query_string => {:query => 'foo'}},
+                          :filters => [
+                            {:filter => {:term => {:attr => 'foo'} }, :boost => 2},
+                            {:filter => {:term => {:attr => 'bar'} }, :boost => 3}
+                          ]
+                        }},
+                      query)
+                        
+      end
+
+    end
+
   end
 end


### PR DESCRIPTION
Adds support for the custom filters score query type ( http://www.elasticsearch.org/guide/reference/query-dsl/custom-filters-score-query/ )
