### PR TITLE
Added support for geo_shape query

### DIFF
--- a/lib/tire/search/query.rb
+++ b/lib/tire/search/query.rb
@@ -109,6 +109,11 @@ module Tire
         @value
       end
 
+      def geo_shape(field, value)
+        @value = { :geo_shape => { field => value }}
+        @value
+      end
+
       def to_hash
         @value
       end


### PR DESCRIPTION
Use like so...

``` ruby
Model.search do
    query do
        boolean do
            must { geo_shape :place_location, { :shape => { :type => 'point', :coordinates => [23,42] }, :relation => 'intersects' } }
        end
     end
end
```
