### PR TITLE
Add nodes method to Tire::Index to allow retrieval of plugin information

### DIFF
--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -119,6 +119,16 @@ module Tire
       MultiJson.decode(@response.body)[@name]['settings']
     end
 
+    def nodes(options={})
+      url = "#{url}/_nodes"
+      unless options.empty?
+        params = options.map { |k, v| "#{k}=#{v}" }
+        url += "?#{params.join('&')}" if params
+      end
+      @response = Configuration.client.get(url)
+      MultiJson.decode(@response.body)['nodes'].values
+    end
+
     def store(*args)
       document, options = args
 

--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -120,13 +120,16 @@ module Tire
     end
 
     def nodes(options={})
-      url = "#{self.url}/_nodes"
+      url = "#{Configuration.url}/_nodes"
       unless options.empty?
         params = options.map { |k, v| "#{k}=#{v}" }
         url += "?#{params.join('&')}" if params
       end
       @response = Configuration.client.get(url)
       MultiJson.decode(@response.body)['nodes'].values
+    ensure
+      curl = %Q|curl -X GET "#{url}"|
+      logged('GET NODES', curl)
     end
 
     def store(*args)

--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -120,7 +120,7 @@ module Tire
     end
 
     def nodes(options={})
-      url = "#{url}/_nodes"
+      url = "#{self.url}/_nodes"
       unless options.empty?
         params = options.map { |k, v| "#{k}=#{v}" }
         url += "?#{params.join('&')}" if params

--- a/test/unit/index_test.rb
+++ b/test/unit/index_test.rb
@@ -240,6 +240,28 @@ module Tire
 
       end
 
+      context "nodes" do
+
+        should "return array of node information" do
+          json =<<-JSON
+          {
+            "nodes" : {
+              "Vkl9oiR_SNyOQRuLFNU9Vw" : { // This appears to be a unique node identifier
+                "name" : "node_name",
+                "transport_address" : "inet[/127.0.0.1:9300]",
+                "hostname" : "test_host",
+                "version" : "0.90.1",
+                "http_address" : "inet[/127.0.0.1:9200]"
+              }
+            }
+          }
+          JSON
+          Configuration.client.stubs(:get).returns(mock_response(json))
+
+          assert_equal 'node_name', @index.nodes.first['name']
+        end
+      end
+
       context "when storing" do
 
         should "set type from Hash :type property" do


### PR DESCRIPTION
This adds a plugin method to Tire::Index

We use this method to check the list of installed plugins

```
index = Tire::Index.new('index_name')
index.nodes(plugin: true)
```

NOTE: we could not get all the Percolator tests to pass locally however as we have not modified this code we believe the issue is unrelated
