### PR TITLE
Prevent load options from being passed to ElasticSearch

### DIFF
--- a/lib/tire/search.rb
+++ b/lib/tire/search.rb
@@ -48,7 +48,7 @@ module Tire
       end
 
       def params
-        options = @options.except(:wrapper, :payload)
+        options = @options.except(:wrapper, :payload, :load)
         options.empty? ? '' : '?' + options.to_param
       end
 

--- a/test/unit/search_test.rb
+++ b/test/unit/search_test.rb
@@ -128,6 +128,14 @@ module Tire
         assert_match /index_1,index_2/, s.to_curl
       end
 
+      should 'not include the load option in queries' do
+        s = Search::Search.new(:load => { :includes => [:author, {:nested => :relation}] }) do
+          query { string 'title:foo' }
+        end
+
+        assert_nil s.to_hash[:load], 'Make sure to ignore load in URL params'
+      end
+
       should "return itself as a Hash" do
         s = Search::Search.new('index') do
           query { string 'title:foo' }


### PR DESCRIPTION
WebMock can't [parse](https://github.com/bblimke/webmock/blob/master/lib/webmock/util/query_mapper.rb#L96) the load/include params that get sent through to ElasticSearch. Rather than fixing WebMock I've opted for the simpler option of removing the load options from the generated search URL.

**N.B.** The tire build was [failing](https://travis-ci.org/karmi/tire) when I cloned the repo.

I'm going to install Tire from this branch and test whether this resolves the issue with WebMock specifically.
