### PR TITLE
Allow import(query) to take longer than 10 min.

### DIFF
--- a/lib/tire/model/import.rb
+++ b/lib/tire/model/import.rb
@@ -67,7 +67,7 @@ module Tire
           include Base
           def import &block
             items = []
-            klass.all.each do |item|
+            klass.all.no_timeout.each do |item|
               items << item
               if items.length % options[:per_page] == 0
                 index.import items, options, &block


### PR DESCRIPTION
Snip from the mongodb doc:

By default, the server will automatically close the cursor after 10 minutes of inactivity or if client has exhausted the cursor. To override this behavior, you can specify the noTimeout wire protocol flag in your query; however, you should either close the cursor manually or exhaust the cursor.

http://docs.mongodb.org/manual/core/read-operations/

This especially happens if a lot of data is going to be index.
