### PR TITLE
Update __find_records_by_ids to implement Strategy per ORM.

### DIFF
--- a/lib/tire/results/collection.rb
+++ b/lib/tire/results/collection.rb
@@ -153,7 +153,55 @@ module Tire
       end
 
       def __find_records_by_ids(klass, ids)
-        @options[:load] === true ? klass.find(ids) : klass.find(ids, @options[:load])
+        Strategy.from_class(klass, @options).find(ids)
+      end
+    end
+
+    # Importing strategies for common persistence frameworks (ActiveModel, Mongoid), as well as
+    # pagination libraries (WillPaginate, Kaminari), or a custom strategy.
+    module Strategy
+      def self.from_class(klass, options={})
+        return const_get(options[:strategy]).new(klass, options) if options[:strategy]
+
+        case
+        when defined?(::ActiveRecord) && klass.ancestors.include?(::ActiveRecord::Base)
+          ActiveRecord.new klass, options
+        else
+          Default.new klass, options
+        end
+      end
+
+      module Base
+        attr_reader :klass, :options
+
+        def initialize(klass, options={})
+          @klass   = klass
+          @options = options
+        end
+      end
+
+      class ActiveRecord
+        include Base
+
+        def find(ids)
+          if options[:load] === true
+            klass.where(:id => ids)
+          else
+            klass.where(:id => ids).all(options[:load])
+          end
+        end
+      end
+
+      class Default
+        include Base
+
+        def find(ids)
+          if options[:load] === true
+            klass.find(ids)
+          else
+            klass.find(ids, options[:load])
+          end
+        end
       end
     end
 

--- a/test/unit/results_collection_test.rb
+++ b/test/unit/results_collection_test.rb
@@ -263,7 +263,7 @@ module Tire
           Tire::Results::Strategy::ActiveRecord => lambda { |model| ActiveRecordArticle.expects(:where).with(:id => [1]).returns([model]) }
         }.each_pair do |strategy, expects|
           should "yield the model instance and the raw hit for #{strategy}" do
-            Tire::Results::Strategy.stubs(:from_class).returns(strategy.new(ActiveRecordArticle, load: true))
+            Tire::Results::Strategy.stubs(:from_class).returns(strategy.new(ActiveRecordArticle, :load => true))
 
             response = { 'hits' => { 'hits' => [ {'_id' => 1, '_score' => 0.5, '_type' => 'active_record_article'} ] } }
 


### PR DESCRIPTION
I haven't done much for the other ORMs as I am not too familiar with them. But this does give a good base to add customizations.
