### PR TITLE
Fixing settings failure problem where there is no index

### DIFF
--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -116,7 +116,7 @@ module Tire
 
     def settings
       @response = Configuration.client.get("#{url}/_settings")
-      MultiJson.decode(@response.body)[@name]['settings']
+      MultiJson.decode(@response.body).fetch(@name, {}).fetch('settings', {})
     end
 
     def store(*args)

--- a/test/unit/index_test.rb
+++ b/test/unit/index_test.rb
@@ -237,7 +237,16 @@ module Tire
 
           assert_equal '20', @index.settings['index.number_of_shards']
         end
-
+        
+        should "return a blank hash for settings if the index is missing" do
+          json = <<-JSON
+            {"error":"IndexMissingException[[foo] missing]","status":404}
+          JSON
+          
+          Configuration.client.stubs(:get).returns(mock_response(json, 404))
+          
+          assert_equal ({}), Tire.index('foo').settings
+        end
       end
 
       context "when storing" do


### PR DESCRIPTION
# What

If you have an index that doesn't exist like Tire.index('foobaz') and call the method settings on it, it will error out due to a nil trying to be accessed like a hash.

This aims to fix that by returning a blank hash instead.

Since Tire.index('foobaz') returns an index even though one isn't made I figured this would be the approach you would like.
# How to test

I put a spec in there to ensure that the error doesn't happen in the future.

Let me know if there's something I can change! Thanks!
