### PR TITLE
Fixing aliasing issue when index doesn't exist

### DIFF
--- a/lib/tire/alias.rb
+++ b/lib/tire/alias.rb
@@ -91,13 +91,16 @@ module Tire
     #
     def self.all(index=nil)
       @response = Configuration.client.get [Configuration.url, index, '_aliases'].compact.join('/')
-
+      return [] if @response.code != 200
+      
       aliases = MultiJson.decode(@response.body).inject({}) do |result, (index, value)|
         # 1] Skip indices without aliases
         next result if value['aliases'].empty?
 
         # 2] Build a reverse map of hashes (alias => indices, config)
-        value['aliases'].each do |key, value| (result[key] ||= { 'indices' => [] }).update(value)['indices'].push(index) end
+        value['aliases'].each do |key, value| 
+          (result[key] ||= { 'indices' => [] }).update(value)['indices'].push(index) 
+        end
         result
       end
 

--- a/test/unit/index_test.rb
+++ b/test/unit/index_test.rb
@@ -91,6 +91,16 @@ module Tire
 
         assert_equal ['foo'], @index.aliases.map(&:name)
       end
+      
+      should "return an empty array of aliases for a non-existant index" do
+        json = <<-JSON
+        {"error":"IndexMissingException[[zomg] missing]","status":404}
+        JSON
+        
+        Configuration.client.expects(:get).returns(mock_response(json, 404))
+        
+        assert_equal [], Tire.index('zomg').aliases
+      end
 
       should "return properties of an alias" do
         json = {'dummy' => { 'aliases' => {'foo' => { 'filter' => { 'term' => { 'user' => 'john' } }}} }}.to_json


### PR DESCRIPTION
# What

The problem is if you use Tire.index('foobaz').aliases it causes an error instead of returning a blank array.

This aims to fix that by returning [] for anything that's not a 200 status code.
# How to test

The spec should show you how to test the code but basically the use case is Tire.index('foobaz').aliases or Tire::Alias.all('foobaz') either gets the error
