### PR TITLE
Get rid of Rails 4 deprecation warnings

### DIFF
--- a/lib/tire/results/collection.rb
+++ b/lib/tire/results/collection.rb
@@ -153,7 +153,7 @@ module Tire
       end
 
       def __find_records_by_ids(klass, ids)
-        @options[:load] === true ? klass.find(ids) : klass.find(ids, @options[:load])
+        @options[:load] === true ? klass.find(ids) : klass.includes(@options[:load].symbolize_keys[:include]).find(ids)
       end
     end
 


### PR DESCRIPTION
Get rid of the DEPRECATION WARNING: Passing options to #find is deprecated. Please build a scope and then call #find on it.
