### PR TITLE
Fix #has_attribute? on persistent models.

### DIFF
--- a/lib/tire/model/persistence/attributes.rb
+++ b/lib/tire/model/persistence/attributes.rb
@@ -108,7 +108,7 @@ module Tire
           end
 
           def has_attribute?(name)
-            properties.include?(name.to_s)
+            self.class.properties.include?(name.to_s)
           end
           alias :has_property? :has_attribute?
 

--- a/test/unit/model_persistence_test.rb
+++ b/test/unit/model_persistence_test.rb
@@ -262,6 +262,18 @@ module Tire
             assert article.respond_to?(:published_on)
           end
 
+          should "return true for has_attribute? calls for defined attributes" do
+            article = PersistentArticle.new :title => 'Test'
+
+            assert article.has_attribute?(:title)
+            assert article.has_attribute?(:published_on)
+          end
+
+          should "return false for has_attribute? calls for unknown attributes" do
+            article = PersistentArticle.new :title => 'Test'
+            assert ! article.has_attribute?(:krapulitz)
+          end
+
           should "have attribute names" do
             article = PersistentArticle.new :title => 'Test', :tags => ['one', 'two']
             assert_equal ['published_on', 'tags', 'title'], article.attribute_names


### PR DESCRIPTION
# has_attribute? from Tire::Model::Persistence raises "undefined local variable or method `properties' for ..." error. The pull-request fixes the issue.

By the way, if nobody has ever complained about the issue, it might be more wisdom to just remove the unused method from API.

P. S. Thanks for such good gem.
