### PR TITLE
Add rake tire:indices:list task

### DIFF
--- a/lib/tire/tasks.rb
+++ b/lib/tire/tasks.rb
@@ -177,4 +177,15 @@ namespace :tire do
 
   end
 
+  namespace :indices do
+    desc 'List existing indices'
+    task :list do
+      status_url      = "#{Tire::Configuration.url}/_status"
+      status_response = Tire::HTTP::Client::RestClient.get(status_url)
+      status_data     = MultiJson.decode(status_response.body)
+
+      puts status_data['indices'].keys
+    end
+  end
+
 end


### PR DESCRIPTION
It would be nice to have a rake task to list existing indices, together with the existing tasks to add/remove them.
