### PR TITLE
Don't remove `match` query followed by `ids` query

### DIFF
--- a/lib/tire/search/query.rb
+++ b/lib/tire/search/query.rb
@@ -92,8 +92,19 @@ module Tire
       end
 
       def ids(values, type=nil)
-        @value = { :ids => { :values => Array(values) }  }
-        @value[:ids].update(:type => type) if type
+        value = { :values => Array(values) }
+        value.update(:type => type) if type
+
+        if @value[:match] && !@value[:bool]
+          # Construct boolean block if a `match` query is already given.
+          original_query = @value.dup
+          @value = { :bool => {} }
+          @value[:bool][:must] = [original_query, { :ids => value }]
+        elsif @value[:bool]
+          (@value[:bool][:must] ||= []) << { :ids => value }
+        else
+          @value[:ids] = value
+        end
         @value
       end
 

--- a/test/unit/search_query_test.rb
+++ b/test/unit/search_query_test.rb
@@ -508,6 +508,16 @@ module Tire::Search
         assert_equal 2, query.to_hash[:bool][:must].size
       end
 
+      should "search for documents by IDs and a field" do
+        query = Query.new
+        query.match(:foo, 'bar')
+        query.ids(1)
+
+        assert_equal( [{ :match => { :foo => { :query => 'bar' } } },
+                       { :ids => { :values => [1] } }],
+                      query.to_hash[:bool][:must] )
+      end
+
     end
 
     context "NestedQuery" do


### PR DESCRIPTION
When the following code is executed, a json (query) containing `ids` and `match` queries should be printed.

``` ruby
Tire.search 'article' do
  query do
    match :foo, 1
    ids [1, 2, 3]
  end
  puts to_json
end
```

However this code prints the following, the query missing `match` block.

``` js
{
  "query": {
    "ids": {
      "values": [
        1,
        2,
        3
      ]
    }
  }
}
```

This PR resolve the problem to build correct queries as follows.

``` js
{
  "query": {
    "bool": {
      "must": [
        {
          "match": {
            "foo": {
              "query": 1
            }
          }
        },
        {
          "ids": {
            "values": [
              1,
              2,
              3
            ]
          }
        }
      ]
    }
  }
}
```
