### PR TITLE
Add support for bulk update

### DIFF
--- a/test/integration/bulk_test.rb
+++ b/test/integration/bulk_test.rb
@@ -49,6 +49,24 @@ module Tire
         assert_equal 0, Tire.search('bulk-test') { query {all} }.results.size
       end
 
+      should 'update documents in bulk' do
+        @index.bulk_store @articles, refresh: true
+
+        documents = @articles.map do |a|
+          {
+            id: a[:id],
+            type: a[:type],
+            doc: { title: "#{a[:title]}-updated" }
+          }
+        end
+        @index.bulk_update documents, refresh: true
+
+        documents = Tire.search('bulk-test') { query {all} }.results.to_a
+        assert_equal 'one-updated', documents[0][:title]
+        assert_equal 'two-updated', documents[1][:title]
+        assert_equal 'three-updated', documents[2][:title]
+      end
+
       should "allow to feed search results to bulk API" do
         (1..10).to_a.each { |i| @index.store id: i }
         @index.refresh


### PR DESCRIPTION
This pull adds support for elasticsearch's new (since 0.90.1) bulk update endpoint.

I'm using it in our application with the following code to add an updated_at timestamp to our Contact model.

``` ruby
# update mapping
index = Tire::Index.new(Contact.tire.index_name)
puts index.mapping(
  Contact.tire.document_type,
  properties: {
    updated_at: {
      type: 'date',
      format: 'date_time_no_millis'
    }
  }
)

# add data
Contact.find_in_batches do |batch|
  documents = batch.map do |contact|
    {
      id: contact.id,
      type: Contact.tire.document_type,
      _routing: contact.account_id,
      doc: ContactSearchSerializer.new(contact, only: :updated_at).as_json
    }
  end
  puts index.bulk_update(documents)
end
```
