### PR TITLE
Add out_of_range? alias for Kaminari support

### DIFF
--- a/lib/tire/results/pagination.rb
+++ b/lib/tire/results/pagination.rb
@@ -52,6 +52,7 @@ module Tire
       alias :total_count  :total_entries
       alias :num_pages    :total_pages
       alias :offset_value :offset
+      alias :out_of_range? :out_of_bounds?
 
       def first_page?
         current_page == 1

--- a/test/unit/results_collection_test.rb
+++ b/test/unit/results_collection_test.rb
@@ -69,7 +69,7 @@ module Tire
 
       should "be kaminari compatible" do
         collection = Results::Collection.new(@default_response)
-        %w(limit_value total_count num_pages offset_value first_page? last_page?).each do |method|
+        %w(limit_value total_count num_pages offset_value first_page? last_page? out_of_range?).each do |method|
           assert_respond_to collection, method
         end
       end


### PR DESCRIPTION
Kaminari's method is called `out_of_range?`, but tire uses `out_of_bounds?`. I added the alias to make integration with Kaminari easier.
