### PR TITLE
Cast persistent model attributes according to defined property type on field (when String, Float, or Integer)

### DIFF
--- a/lib/tire/model/persistence/attributes.rb
+++ b/lib/tire/model/persistence/attributes.rb
@@ -121,6 +121,10 @@ module Tire
           # instances and automatically convert UTC formatted strings to Time.
           #
           def __cast_value(name, value)
+
+            property_mapping = self.class.mapping[name.to_sym]
+            type_class = property_mapping[:type].camelize if property_mapping
+
             case
 
               when klass = self.class.property_types[name.to_sym]
@@ -132,6 +136,13 @@ module Tire
 
               when value.is_a?(Hash)
                 Hashr.new(value)
+              
+              # if the property type can be easily casted to and
+              # the value's type does not match the mapping type
+              when %w[String Float Integer].include?(type_class) &&
+                   %w[String Float Integer Fixnum].include?(value.class.name) &&
+                   !value.is_a?(type_class.constantize)
+                send(type_class, value)
 
               else
                 # Strings formatted as <http://en.wikipedia.org/wiki/ISO8601> are automatically converted to Time

--- a/test/models/persistent_article_with_types.rb
+++ b/test/models/persistent_article_with_types.rb
@@ -1,0 +1,9 @@
+class PersistentArticleWithTypes
+
+  include Tire::Model::Persistence
+
+  property :title, :type => 'string'
+  property :comment_count, :type => 'integer'
+  property :average_score, :type => 'float'
+
+end

--- a/test/unit/model_persistence_test.rb
+++ b/test/unit/model_persistence_test.rb
@@ -311,6 +311,13 @@ module Tire
             assert_equal '4chan',       article.comments.first.nick
           end
 
+          should "automatically cast value to defined property type on strings, integers, and floats" do
+            article = PersistentArticleWithTypes.new :title => 12345, :comment_count => '12', :average_score => 10
+            assert_equal '12345', article.title
+            assert_equal 12, article.comment_count
+            assert_equal 10.0, article.average_score
+          end
+
           should "automatically format strings in ISO8601 with the default UTC designator" do
             article = PersistentArticle.new :published_on => '2011-11-01T23:00:00Z'
             assert_instance_of Time, article.published_on


### PR DESCRIPTION
``` ruby
class PersistentArticleWithTypes
  include Tire::Model::Persistence

  property :title, :type => 'string'
  property :comment_count, :type => 'integer'
  property :average_score, :type => 'float'
end

article = PersistentArticleWithTypes.new :title => 12345, :comment_count => '12', :average_score => 10
assert_equal '12345', article.title
assert_equal 12, article.comment_count
assert_equal 10.0, article.average_score
```

The above example is a model and subsequent unit test showing the desired functionality.  While the example is definitely contrived, this change will prevent extra steps in the controller to cast param values to the appropriate type.  I'm developing a Rails app with Tire as the primary ORM (using ES for storage), and the issue has came up several times now.  Unless I'm totally wrong, I do believe this reflects the default behavior of AR and Mongoid.
