### PR TITLE
Lambda/proc property defaults should be called at record initialization as opposed to time of property definition

### DIFF
--- a/lib/tire/model/persistence/attributes.rb
+++ b/lib/tire/model/persistence/attributes.rb
@@ -46,7 +46,7 @@ module Tire
 
             # Save property default value (when relevant):
             unless (default_value = options.delete(:default)).nil?
-              property_defaults[name.to_sym] = default_value.respond_to?(:call) ? default_value.call : default_value
+              property_defaults[name.to_sym] = default_value
             end
 
             # Save property casting (when relevant):
@@ -92,7 +92,15 @@ module Tire
             #
             property_defaults = self.class.property_defaults.inject({}) do |hash, item|
               key, value = item
-              hash[key.to_sym] = value.class.respond_to?(:new) ? value.clone : value
+
+              hash[key.to_sym] = if value.respond_to?(:call)
+                value.call
+              elsif value.class.respond_to?(:new)
+                value.clone
+              else
+                value
+              end
+
               hash
             end
             __update_attributes(property_defaults.merge(attributes))

--- a/test/unit/model_persistence_test.rb
+++ b/test/unit/model_persistence_test.rb
@@ -214,9 +214,11 @@ module Tire
             assert_equal false, article.hidden
           end
 
-          should "evaluate lambdas as default values" do
+          should "evaluate lambdas as default values at time of initialization" do
+            now = Time.now
+            Time.stubs(:now).returns(now)
             article = PersistentArticleWithDefaults.new
-            assert_equal Time.now.year, article.created_at.year
+            assert_equal now, article.created_at
           end
 
           should "not affect default value" do


### PR DESCRIPTION
``` ruby
class PersistentArticleWithDefaults
  include Tire::Model::Persistence

  property :created_at, :default => lambda { Time.now }
end
```

As it is currently in the master branch, lambda-based defaults for properties are evaluated at the time of definition.  This causes all records created to have the same value for "created_at", which does not appear to be the intended behavior (unless I am wrong).
