### PR TITLE
:class instance of a property value should be able to reference the "embedding" doc (or parent)

### DIFF
--- a/lib/tire/model/persistence/attributes.rb
+++ b/lib/tire/model/persistence/attributes.rb
@@ -125,9 +125,9 @@ module Tire
 
               when klass = self.class.property_types[name.to_sym]
                 if klass.is_a?(Array) && value.is_a?(Array)
-                  value.map { |v| klass.first.new(v) }
+                  value.map { |v| klass.first.new(self, v) }
                 else
-                  klass.new(value)
+                  klass.new(self, value)
                 end
 
               when value.is_a?(Hash)

--- a/test/models/persistent_article_with_casting.rb
+++ b/test/models/persistent_article_with_casting.rb
@@ -1,13 +1,21 @@
 class Author
   attr_accessor :first_name, :last_name
-  def initialize(attributes)
+  def initialize(article, attributes)
     @first_name = HashWithIndifferentAccess.new(attributes)[:first_name]
     @last_name  = HashWithIndifferentAccess.new(attributes)[:last_name]
   end
 end
 
 class Comment
-  def initialize(params);                      @attributes = HashWithIndifferentAccess.new(params);  end
+  def initialize(article, params)
+    @article = article
+    @attributes = HashWithIndifferentAccess.new(params)
+  end
+
+  def posted_within
+    posted_at - @article.created_at
+  end
+
   def method_missing(method_name, *arguments); @attributes[method_name];                             end
   def as_json(*);                              @attributes;                                          end
 end
@@ -24,5 +32,6 @@ class PersistentArticleWithCastedCollection
   include Tire::Model::Persistence
 
   property :title
+  property :created_at, :type => 'date'
   property :comments, :class => [Comment]
 end

--- a/test/unit/model_persistence_test.rb
+++ b/test/unit/model_persistence_test.rb
@@ -316,7 +316,7 @@ module Tire
             posted_at = article_created + 10.minutes
             article = PersistentArticleWithCastedCollection.new :created_at => article_created,
                                                                 :title => 'Test',
-                                                                :comments => [{:nick => '4chan', :body => 'WHY U NO?', posted_at: posted_at}]
+                                                                :comments => [{:nick => '4chan', :body => 'WHY U NO?', :posted_at => posted_at}]
             comment = article.comments.first
             assert_equal comment.posted_within, 10.minutes
           end

--- a/test/unit/model_persistence_test.rb
+++ b/test/unit/model_persistence_test.rb
@@ -311,6 +311,16 @@ module Tire
             assert_equal '4chan',       article.comments.first.nick
           end
 
+          should "be referenced by the custom class" do
+            article_created = Time.now
+            posted_at = article_created + 10.minutes
+            article = PersistentArticleWithCastedCollection.new :created_at => article_created,
+                                                                :title => 'Test',
+                                                                :comments => [{:nick => '4chan', :body => 'WHY U NO?', posted_at: posted_at}]
+            comment = article.comments.first
+            assert_equal comment.posted_within, 10.minutes
+          end
+
           should "automatically format strings in ISO8601 with the default UTC designator" do
             article = PersistentArticle.new :published_on => '2011-11-01T23:00:00Z'
             assert_instance_of Time, article.published_on


### PR DESCRIPTION
In the style of Mongoid's embedded documents, it would be nice (really nice) for property classes to reference their respective "owner" or "parent" docs (`article.comments.first.article`).  The example below will hopefully illustrate the problem.  The only existing solutions are accessor methods in the root model (e.g. `article.comment_posted_within(comment)`) or storing the needed attributes from the root model (such as :created_at in the test) within each embedded object, which is probably a little overkill.

``` ruby
class Comment
  def initialize(article, attrs)
    @article = article
    @attributes = HashWithIndifferentAccess.new(attrs)
  end

  def posted_within
    posted_at - @article.created_at
  end

  # ... method_missing and whatnot
end

class Article
  include Tire::Model::Persistence

  property :created_at, :type => 'date'
  property :comments, :class => [Comment]
end

now = Time.now
posted_at = now + 10.minutes
article = Article.new :created_at => now,
                      :comments => [{:body => 'comment body', :posted_at => posted_at}]
assert_equal article.comments.first.posted_within, 10.minutes
```
