### PR TITLE
Fix possible double require of classes

### DIFF
--- a/lib/tire/tasks.rb
+++ b/lib/tire/tasks.rb
@@ -121,10 +121,12 @@ namespace :tire do
 
       puts "[IMPORT] Loading models from: #{dir}"
       Dir.glob(File.join("#{dir}/**/*.rb")).each do |path|
-        require path
-
         model_filename = path[/#{Regexp.escape(dir.to_s)}\/([^\.]+).rb/, 1]
-        klass          = model_filename.camelize.constantize
+        begin
+          klass = model_filename.camelize.constantize
+        rescue NameError
+          require(path) ? retry : raise
+        end
 
         # Skip if the class doesn't have Tire integration
         next unless klass.respond_to?(:tire)


### PR DESCRIPTION
When loading environment before tire:import:all, via `rake environment tire:import:all` it is possible that models are already loaded when tire tries to load them.
This can cause redefinition of constants and all other kinds of havoc.

This fix first tries to constantize the models to see if they are already loaded before trying to require them.

See issue #744 for discussion.
