### PR TITLE
Skipping model/concerns folder

### DIFF
--- a/lib/tire/tasks.rb
+++ b/lib/tire/tasks.rb
@@ -124,6 +124,9 @@ namespace :tire do
         require path
 
         model_filename = path[/#{Regexp.escape(dir.to_s)}\/([^\.]+).rb/, 1]
+
+        next if model_filename.match(/^concerns\//i) # Skip concerns/ folder
+
         klass          = model_filename.camelize.constantize
 
         # Skip if the class doesn't have Tire integration


### PR DESCRIPTION
In rails models can have "concerns" (a default pattern in rails4) - which help skinny out models and separate common code among them. But if you try to load them you'll get exceptions since they aren't always prefixed with `concerns::` but yet live in the `model/concerns` folder. This causes the call to `constantize` to fail.

There might be a more elegant way to solve this, but here we have a quick and dirty solution.

What do you think?
