### PR TITLE
Disable mongoid's identity map during importing

### DIFF
--- a/lib/tire/model/import.rb
+++ b/lib/tire/model/import.rb
@@ -67,11 +67,13 @@ module Tire
           include Base
           def import &block
             items = []
-            klass.all.each do |item|
-              items << item
-              if items.length % options[:per_page] == 0
-                index.import items, options, &block
-                items = []
+            ::Mongoid.unit_of_work(:disable => :all) do
+              klass.all.each do |item|
+                items << item
+                if items.length % options[:per_page] == 0
+                  index.import items, options, &block
+                  items = []
+                end
               end
             end
             index.import items, options, &block unless items.empty?


### PR DESCRIPTION
Iterating over all documents in collection with enabled identity map will fill memory until task will be killed by OS.

From mongoid doc: "When a document is now loaded from the database, it is automatically added to the identity map by its class and id. Subsequent request for that document by its id will not hit the database, but rather pull the document back from the identity map itself".

See http://mongoid.org/en/mongoid/docs/identity_map.html for additional information about identity map.
