### PR TITLE
Fix ElasticSearch highlighting doc page link

### DIFF
--- a/lib/tire/search/highlight.rb
+++ b/lib/tire/search/highlight.rb
@@ -1,7 +1,7 @@
 module Tire
   module Search
 
-    # http://www.elasticsearch.org/guide/reference/api/search/highlighting.html
+    # http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-highlighting.html
     #
     class Highlight
 


### PR DESCRIPTION
http://www.elasticsearch.org/guide/reference/api/search/highlighting.html redirects to a 404
