### PR TITLE
Instance eval with delegation proof of concept.

### DIFF
--- a/lib/tire/model/search.rb
+++ b/lib/tire/model/search.rb
@@ -73,6 +73,7 @@ module Tire
           end
 
           options   = default_options.update(options)
+          options[:context] = eval "self", block.binding if block_given?
           sort      = Array( options.delete(:order) || options.delete(:sort) )
 
           s = Tire::Search::Search.new(options.delete(:index), options)

--- a/lib/tire/search.rb
+++ b/lib/tire/search.rb
@@ -4,7 +4,8 @@ module Tire
 
     class Search
 
-      attr_reader :indices, :types, :query, :facets, :filters, :options, :explain, :script_fields
+      attr_reader :indices, :types, :query, :facets, :filters, :options, :explain,
+                  :script_fields, :context
 
       def initialize(indices=nil, options={}, &block)
         if indices.is_a?(Hash)
@@ -15,6 +16,7 @@ module Tire
         end
         @types   = Array(options.delete(:type)).map { |type| Utils.escape(type) }
         @options = options
+        @context = options[:context]
 
         @path    = ['/', @indices.join(','), @types.join(','), '_search'].compact.join('/').squeeze('/')
 
@@ -53,7 +55,7 @@ module Tire
       end
 
       def query(&block)
-        @query = Query.new
+        @query = Query.new(context: context)
         block.arity < 1 ? @query.instance_eval(&block) : block.call(@query)
         self
       end

--- a/lib/tire/search/query.rb
+++ b/lib/tire/search/query.rb
@@ -2,11 +2,16 @@ module Tire
   module Search
 
     class Query
-      attr_accessor :value
+      attr_accessor :value, :context
 
-      def initialize(&block)
+      def initialize(options = {}, &block)
         @value = {}
+        @context = options[:context]
         block.arity < 1 ? self.instance_eval(&block) : block.call(self) if block_given?
+      end
+
+      def method_missing(method, *args, &block)
+        context.send method, *args, &block
       end
 
       def term(field, value, options={})

--- a/test/integration/active_model_searchable_test.rb
+++ b/test/integration/active_model_searchable_test.rb
@@ -18,6 +18,10 @@ module Tire
       SupermodelArticle.all.each { |a| a.destroy }
     end
 
+    def dummy_method_for_block_context
+      "test"
+    end
+
     context "ActiveModel integration" do
 
       setup    do
@@ -85,6 +89,20 @@ module Tire
         assert_equal 'bar',    results.first.title
         assert_equal 'abc123', results.first.id
       end
+
+      should "return result of query when using methods defined in the scope" do
+        a = SupermodelArticle.new :title => 'Test'
+        a.save
+        a.index.refresh
+
+        s = SupermodelArticle.search do
+          query { match :title, dummy_method_for_block_context }
+        end
+
+        assert_equal 1, s.results.count
+      end
+
+
 
       should "return facets" do
         a = SupermodelArticle.new :title => 'Test'

--- a/test/unit/model_search_test.rb
+++ b/test/unit/model_search_test.rb
@@ -40,10 +40,15 @@ module Tire
           Tire::Search::Search.
             expects(:new).
             with('active_model_articles', { :type => 'active_model_article' }).
-            returns(@stub).
-            twice
+            returns(@stub)
 
           ActiveModelArticle.search 'foo'
+
+          Tire::Search::Search.
+            expects(:new).
+            with('active_model_articles', { :type => 'active_model_article', :context => self }).
+            returns(@stub)
+
           ActiveModelArticle.search { query { string 'foo' } }
         end
 
@@ -52,27 +57,65 @@ module Tire
           second = 'another-custom-index-name'
           expected_options = { :type => ActiveModelArticleWithCustomIndexName.document_type }
 
-          Tire::Search::Search.expects(:new).with(first, expected_options).returns(@stub).twice
+          Tire::Search::Search.
+            expects(:new).
+            with(first, expected_options).
+            returns(@stub)
           ActiveModelArticleWithCustomIndexName.index_name first
           ActiveModelArticleWithCustomIndexName.search 'foo'
+
+          Tire::Search::Search.
+            expects(:new).
+            with(first, expected_options.merge(:context => self)).
+            returns(@stub)
+
           ActiveModelArticleWithCustomIndexName.search { query { string 'foo' } }
 
-          Tire::Search::Search.expects(:new).with(second, expected_options).returns(@stub).twice
+          Tire::Search::Search.
+            expects(:new).
+            with(second, expected_options).
+            returns(@stub)
           ActiveModelArticleWithCustomIndexName.index_name second
           ActiveModelArticleWithCustomIndexName.search 'foo'
+
+          Tire::Search::Search.
+            expects(:new).
+            with(second, expected_options.merge(:context => self)).
+            returns(@stub)
+
           ActiveModelArticleWithCustomIndexName.search { query { string 'foo' } }
 
-          Tire::Search::Search.expects(:new).with(first, expected_options).returns(@stub).twice
+          Tire::Search::Search.
+            expects(:new).
+            with(first, expected_options).
+            returns(@stub)
+
           ActiveModelArticleWithCustomIndexName.index_name first
           ActiveModelArticleWithCustomIndexName.search 'foo'
+
+          Tire::Search::Search.
+            expects(:new).
+            with(first, expected_options.merge(:context => self)).
+            returns(@stub)
+
           ActiveModelArticleWithCustomIndexName.search { query { string 'foo' } }
         end
 
         should "search in custom type" do
           name = ActiveModelArticleWithCustomDocumentType.index_name
-          Tire::Search::Search.expects(:new).with(name, { :type => 'my_custom_type' }).returns(@stub).twice
+          Tire::Search::Search.
+            expects(:new).
+            with(name, { :type => 'my_custom_type' }).
+            returns(@stub)
 
           ActiveModelArticleWithCustomDocumentType.search 'foo'
+
+          Tire::Search::Search.
+            expects(:new).
+            with(name, { :type => 'my_custom_type', :context => self }).
+            returns(@stub)
+
+
           ActiveModelArticleWithCustomDocumentType.search { query { string 'foo' } }
         end
 
@@ -80,10 +123,16 @@ module Tire
           Tire::Search::Search.
             expects(:new).
             with(ActiveModelArticle.index_name, { :type => 'custom_type' }).
-            returns(@stub).
-            twice
+            returns(@stub)
 
           ActiveModelArticle.search 'foo', :type => 'custom_type'
+
+          Tire::Search::Search.
+            expects(:new).
+            with(ActiveModelArticle.index_name, { :type => 'custom_type', :context => self }).
+            returns(@stub)
+
+
           ActiveModelArticle.search( :type => 'custom_type' ) { query { string 'foo' } }
         end
 
@@ -91,10 +140,16 @@ module Tire
           Tire::Search::Search.
             expects(:new).
             with('custom_index', { :type => ActiveModelArticle.document_type }).
-            returns(@stub).
-            twice
+            returns(@stub)
 
           ActiveModelArticle.search 'foo', :index => 'custom_index'
+
+          Tire::Search::Search.
+            expects(:new).
+            with('custom_index', { :type => ActiveModelArticle.document_type, :context => self }).
+            returns(@stub)
+
+
           ActiveModelArticle.search( :index => 'custom_index' ) do
             query { string 'foo' }
           end


### PR DESCRIPTION
Hi,

I've been using tire and I've been facing the following issue. Sometimes, I would like to use some helper methods within the search blocks, but I always get an undefined method exception. In the current state,  the only work around that I found for that so far is to write the search methods like this:

``` ruby

def execute
  Model.tire.search(page: page, load: true) do |s|
    s.query do |q|
      q.boolean do |b|
        b.must { |condition| condition.string "..."  } if tags
        ...
      end
      ...
    end
    s.sort { by :id, "desc" }
  end
end

def tags
    ...
end
```

I notice that this has to do with the use of instance eval inside the DSL. I found this interesting article where they explained a workaround for that:

http://www.dan-manges.com/blog/ruby-dsls-instance-eval-with-delegation

I started a proof of concept to see if it works with tire. It seems to be working. 

Is there a reason why you guys didn't allow this? I could implement this in all the other places, but I wanted to have your feedback, I don't know if I'm missing something here and there is a reason to not do this. 

Cheers! 
