### PR TITLE
Update index response

### DIFF
--- a/lib/tire/model/search.rb
+++ b/lib/tire/model/search.rb
@@ -147,6 +147,7 @@ module Tire
             else
               response = index.store( instance, {:percolate => percolator} )
               instance.tire.matches = response['matches'] if instance.tire.respond_to?(:matches=)
+              @response = response
               self
             end
           end
@@ -245,9 +246,10 @@ module Tire
 
         INTERFACE = public_instance_methods.map(&:to_sym) - Object.public_instance_methods.map(&:to_sym)
 
-        attr_reader :instance
+        attr_reader :instance, :response
         def initialize(instance)
           @instance = instance
+          @response = {}
         end
       end
 

--- a/test/integration/active_record_searchable_test.rb
+++ b/test/integration/active_record_searchable_test.rb
@@ -490,7 +490,7 @@ module Tire
 
 
            ActiveRecordVideo.create! :title => 'Title One', timestamp: Time.now.to_i
-           ActiveRecordPhoto.create! :title => 'Title Two', timestamp: Time.now.to_i
+           ActiveRecordPhoto.create! :title => 'Title Two', timestamp: Time.now.to_i + 1.minute
            ActiveRecordAsset.tire.index.refresh
          end
 

--- a/test/integration/bulk_test.rb
+++ b/test/integration/bulk_test.rb
@@ -62,9 +62,9 @@ module Tire
         @index.bulk_update documents, refresh: true
 
         documents = Tire.search('bulk-test') { query {all} }.results.to_a
-        assert_equal 'one-updated', documents[0][:title]
-        assert_equal 'two-updated', documents[1][:title]
-        assert_equal 'three-updated', documents[2][:title]
+        assert_equal 'one-updated', documents.detect{|doc| doc.id == "1" }.title
+        assert_equal 'two-updated', documents.detect{|doc| doc.id == "2" }.title
+        assert_equal 'three-updated', documents.detect{|doc| doc.id == "3" }.title
       end
 
       should "allow to feed search results to bulk API" do

--- a/test/integration/search_response_test.rb
+++ b/test/integration/search_response_test.rb
@@ -1,0 +1,70 @@
+require 'test_helper'
+#require File.expand_path('../../models/supermodel_article', __FILE__)
+
+module Tire
+
+  class SearchResponseIntegrationTest < Test::Unit::TestCase
+        include Test::Integration
+
+    class ::ActiveModelArticleWithTitle < ActiveModelArticleWithCallbacks
+      mapping do
+        indexes :title, type: :string
+      end
+    end
+
+    class ::ActiveModelArticleWithMalformedTitle < ActiveModelArticleWithCallbacks
+      mapping do
+        indexes :title, type: :string
+      end
+
+      def to_indexed_json
+        json = JSON.parse(super)
+        json["title"] = { key: "value" }
+        json.to_json
+      end
+    end
+
+    def setup
+      super
+      ActiveModelArticleWithTitle.index.delete
+      ActiveModelArticleWithMalformedTitle.index.delete
+    end
+
+    def teardown
+      super
+      ActiveModelArticleWithTitle.index.delete
+      ActiveModelArticleWithMalformedTitle.index.delete
+    end
+
+    context "successful index update" do
+
+      setup do
+        @model = ActiveModelArticleWithTitle.new \
+                   :id      => 1,
+                   :title   => 'Test article',
+                   :content => 'Lorem Ipsum. Dolor Sit Amet.'
+        @response = @model.update_index
+      end
+
+      should "expose the index response on successful update" do
+        assert_equal @response.response["ok"], true
+      end
+
+    end
+
+    context "unsuccessful index update" do
+      setup do
+        ActiveModelArticleWithMalformedTitle.create_elasticsearch_index
+        @model = ActiveModelArticleWithMalformedTitle.new \
+                   :id      => 1,
+                   :title   => 'Test article',
+                   :content => 'Lorem Ipsum. Dolor Sit Amet.'
+        @response = @model.update_index
+      end
+
+      should "expose the index response on update error" do
+        assert_equal @response.response["status"], 400
+      end
+    end
+  end
+end


### PR DESCRIPTION
`Tire::Model::Persistence::Storage` exposes the response from ElasticSearch in the return value of `update_index`.  This pull request does the same for `Tire::Model::Search`, exposes the index response through an attr_reader - mentioned also in this issue from awhile ago (https://github.com/karmi/retire/issues/251). 
