### PR TITLE
Added http error handling to Index#retrieve.

### DIFF
--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -356,6 +356,9 @@ module Tire
       params_encoded      = params.empty? ? '' : "?#{params.to_param}"
 
       @response = Configuration.client.get "#{url}#{params_encoded}"
+      if @response && @response.failure? && @response.code != 404
+        raise RuntimeError, "#{@response.code} > #{@response.body}"
+      end
 
       h = MultiJson.decode(@response.body)
       wrapper = options[:wrapper] || Configuration.wrapper


### PR DESCRIPTION
Unlike `bulk`, `retrieve` didn't have a check for 500 response codes, which led to Tire::Model returning an object from find instead of reporting the error.

This change adds the same handling as in `bulk`, but makes an exception for 404 since that is handled by the `h['exists'] == false` later on.
