### PR TITLE
[PERSISTANCE] fixed getter methods for underscore-options of unsaved rec...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ examples/*.html
 *.log
 .rvmrc
 .rbenv-version
+.idea/
 tmp/

--- a/lib/tire/model/persistence.rb
+++ b/lib/tire/model/persistence.rb
@@ -45,7 +45,7 @@ module Tire
 
           ['_score', '_type', '_index', '_version', 'sort', 'highlight', '_explanation'].each do |attr|
             define_method("#{attr}=") { |value| @attributes ||= {}; @attributes[attr] = value }
-            define_method("#{attr}")  { @attributes[attr] }
+            define_method("#{attr}")  { @attributes.try(:[], attr) }
           end
 
           def self.search(*args, &block)

--- a/lib/tire/version.rb
+++ b/lib/tire/version.rb
@@ -1,5 +1,5 @@
 module Tire
-  VERSION   = "0.6.2"
+  VERSION   = "0.6.2.1"
 
   CHANGELOG =<<-END
     IMPORTANT CHANGES LATELY:

--- a/test/unit/model_persistence_test.rb
+++ b/test/unit/model_persistence_test.rb
@@ -183,6 +183,10 @@ module Tire
             assert_nothing_raised { PersistentArticle.new }
           end
 
+          should "have getter methods for underscore-attributes of unsaved models" do
+            assert_nothing_raised { PersistentArticle.new._version }
+          end
+
           should "have getter methods for attributes" do
             assert_not_nil @article.title
             assert_equal 'Test', @article.title


### PR DESCRIPTION
...ords

For example It fixes this live exception:
[37] pry(main)> PersistentArticle.new(:id => 'someId').persisted?
NoMethodError: undefined method `[]' for nil:NilClass
from /Users/AlexY/.rvm/gems/ruby-2.0.0-p353@startwire/gems/tire-0.6.2/lib/tire/model/persistence.rb:48:in`block (3 levels) in included'
