### PR TITLE
Correct debug log level is 'debug'

### DIFF
--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -258,7 +258,7 @@ module Tire
         end
 
       ensure
-        data = Configuration.logger && Configuration.logger.level.to_s == 'verbose' ? payload.join("\n") : '... data omitted ...'
+        data = Configuration.logger && Configuration.logger.level.to_s == 'debug' ? payload.join("\n") : '... data omitted ...'
         curl = %Q|curl -X POST "#{url}/_bulk" --data-binary '#{data}'|
         logged('_bulk', curl)
       end


### PR DESCRIPTION
The project README suggests setting up debug logging with the following:

``` ruby
 Tire.configure { logger 'elasticsearch.log', :level => 'debug' }
```

This pull fixes the `Index#bulk` debug output to test for the 'debug' log level instead of 'verbose'.
