### PR TITLE
Use Tire::Model::Import:Strategy in rake task

### DIFF
--- a/lib/tire/tasks.rb
+++ b/lib/tire/tasks.rb
@@ -46,7 +46,7 @@ module Tire
         unless progress_bar(klass)
           puts "[IMPORT] Importing '#{klass.to_s}'"
         end
-        klass.tire.import(params) do |documents|
+        Tire::Model::Import::Strategy::from_class(klass, params).import do |documents|
           progress_bar(klass).inc documents.size if progress_bar(klass)
           documents
         end


### PR DESCRIPTION
This allows to import scoped documents in mongoid 3.x

```
rake environment tire:import:model CLASS='Article.where(published: true)'
```

Without it it will import all Article because of Mongoid::Criteria#tire is
proxied to Article::tire
