### PR TITLE
Fixed Index.retrieve so that it works with ES 1.0.0 and previous versions

### DIFF
--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -364,7 +364,7 @@ module Tire
       wrapper = options[:wrapper] || Configuration.wrapper
       if wrapper == Hash then h
       else
-        return nil if h['exists'] == false
+        return nil if (h['exists'] || h['found']) == false
         document = h['_source'] || h['fields'] || {}
         document.update('id' => h['_id'], '_type' => h['_type'], '_index' => h['_index'], '_version' => h['_version'])
         wrapper.new(document)


### PR DESCRIPTION
The latest version of ES breaks the Index#retrieve function, and it no longer returns nil as it should. This fixes it.
