### PR TITLE
rename document_type to tire_document_type

### DIFF
--- a/examples/tire-dsl.rb
+++ b/examples/tire-dsl.rb
@@ -88,7 +88,7 @@ Tire.index 'articles' do
       @attributes.each_pair { |name,value| instance_variable_set :"@#{name}", value }
     end
 
-    # It must provide a `type`, `_type` or `document_type` method for propper mapping.
+    # It must provide a `type`, `_type` or `tire_document_type` method for propper mapping.
     #
     def type
       'article'

--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -496,8 +496,8 @@ module Tire
 
       old_verbose, $VERBOSE = $VERBOSE, nil # Silence Object#type deprecation warnings
       type = case
-        when document.respond_to?(:document_type)
-          document.document_type
+        when document.respond_to?(:tire_document_type)
+          document.tire_document_type
         when document.is_a?(Hash)
           document[:_type] || document['_type'] || document[:type] || document['type']
         when document.respond_to?(:_type)

--- a/lib/tire/model/indexing.rb
+++ b/lib/tire/model/indexing.rb
@@ -124,7 +124,7 @@ module Tire
         end
 
         def mapping_to_hash
-          { document_type.to_sym => mapping_options.merge({ :properties => mapping }) }
+          { tire_document_type.to_sym => mapping_options.merge({ :properties => mapping }) }
         end
 
       end

--- a/lib/tire/model/naming.rb
+++ b/lib/tire/model/naming.rb
@@ -67,15 +67,15 @@ module Tire
         #
         # To get the document type:
         #
-        #     Article.document_type
+        #     Article.tire_document_type
         #
         # To set the document type:
         #
-        #     Article.document_type 'my-custom-type'
+        #     Article.tire_document_type 'my-custom-type'
         #
-        def document_type name=nil
-          @document_type = name if name
-          @document_type || klass.model_name.to_s.underscore
+        def tire_document_type name=nil
+          @tire_document_type = name if name
+          @tire_document_type || klass.model_name.to_s.underscore
         end
       end
 
@@ -87,10 +87,10 @@ module Tire
           instance.class.tire.index_name
         end
 
-        # Proxy to instance method `document_type`.
+        # Proxy to instance method `tire_document_type`.
         #
-        def document_type
-          instance.class.tire.document_type
+        def tire_document_type
+          instance.class.tire.tire_document_type
         end
       end
 

--- a/lib/tire/model/persistence/finders.rb
+++ b/lib/tire/model/persistence/finders.rb
@@ -16,14 +16,14 @@ module Tire
             if args.size > 1
               Tire::Search::Search.new(index.name, :wrapper => self) do |search|
                 search.query do |query|
-                  query.ids(args, document_type)
+                  query.ids(args, tire_document_type)
                 end
                 search.size args.size
               end.results
             else
               case args = args.pop
                 when Fixnum, String
-                  index.retrieve document_type, args, :wrapper => self
+                  index.retrieve tire_document_type, args, :wrapper => self
                 when :all, :first
                   send(args)
                 else
@@ -34,13 +34,13 @@ module Tire
 
           def all
             # TODO: Options like `sort`; Possibly `filters`
-            s = Tire::Search::Search.new(index.name, :type => document_type, :wrapper => self).query { all }
+            s = Tire::Search::Search.new(index.name, :type => tire_document_type, :wrapper => self).query { all }
             s.version(true).results
           end
 
           def first
             # TODO: Options like `sort`; Possibly `filters`
-            s = Tire::Search::Search.new(index.name, :type => document_type, :wrapper => self).query { all }.size(1)
+            s = Tire::Search::Search.new(index.name, :type => tire_document_type, :wrapper => self).query { all }.size(1)
             s.version(true).results.first
           end
 

--- a/lib/tire/model/persistence/storage.rb
+++ b/lib/tire/model/persistence/storage.rb
@@ -25,7 +25,7 @@ module Tire
           end
 
           def delete(&block)
-            DeleteByQuery.new(index_name, {:type => document_type}, &block).perform
+            DeleteByQuery.new(index_name, {:type => tire_document_type}, &block).perform
           end
         end
 

--- a/lib/tire/model/search.rb
+++ b/lib/tire/model/search.rb
@@ -63,7 +63,7 @@ module Tire
         #     Article.search :load => { :include => 'comments' } do ... end
         #
         def search(*args, &block)
-          default_options = {:type => document_type, :index => index.name}
+          default_options = {:type => tire_document_type, :index => index.name}
 
           if block_given?
             options = args.shift || {}
@@ -106,7 +106,7 @@ module Tire
         end
 
         def multi_search(options={}, &block)
-          default_options = {:type => document_type}
+          default_options = {:type => tire_document_type}
           options         = default_options.update(options)
           Tire::Search::Multi::Search.new(index.name, options, &block).results
         end

--- a/lib/tire/model/suggest.rb
+++ b/lib/tire/model/suggest.rb
@@ -3,7 +3,7 @@ module Tire
     module Suggest
       module ClassMethods
         def suggest(*args, &block)
-          default_options = {:type => document_type, :index => index.name}
+          default_options = {:type => tire_document_type, :index => index.name}
 
           if block_given?
             options = args.shift || {}

--- a/test/models/active_model_article_with_custom_document_type.rb
+++ b/test/models/active_model_article_with_custom_document_type.rb
@@ -3,5 +3,5 @@
 require File.expand_path('../active_model_article', __FILE__)
 
 class ActiveModelArticleWithCustomDocumentType < ActiveModelArticle
-  document_type 'my_custom_type'
+  tire_document_type 'my_custom_type'
 end

--- a/test/models/persistent_article_in_namespace.rb
+++ b/test/models/persistent_article_in_namespace.rb
@@ -1,6 +1,6 @@
 # Example namespaced class with Elasticsearch persistence
 #
-# The `document_type` is `my_namespace/persistent_article_in_namespace`
+# The `tire_document_type` is `my_namespace/persistent_article_in_namespace`
 #
 
 module MyNamespace

--- a/test/unit/index_test.rb
+++ b/test/unit/index_test.rb
@@ -287,7 +287,7 @@ module Tire
 
           module MyNamespace
             class MyModel
-              def document_type;   "my_namespace/my_model"; end
+              def tire_document_type;   "my_namespace/my_model"; end
               def to_indexed_json; "{}";                    end
             end
           end
@@ -812,7 +812,7 @@ module Tire
             returns(mock_response('{}'), 200)
 
           class MyModel
-            def document_type;   "my_model";                                      end
+            def tire_document_type;   "my_model";                                      end
             def to_hash;         { :id => 1, :title => 'Foo', :_routing => 'A' }; end
             def to_indexed_json; MultiJson.encode(to_hash);                       end
           end
@@ -822,7 +822,7 @@ module Tire
 
         context "with namespaced models" do
 
-          should "not URL-escape the document_type" do
+          should "not URL-escape the tire_document_type" do
             Configuration.client.expects(:post).with do |url, payload|
               # puts url, payload
               assert_equal "#{Configuration.url}/my_namespace_my_models/_bulk", url
@@ -832,7 +832,7 @@ module Tire
 
             module MyNamespace
               class MyModel
-                def document_type;   "my_namespace/my_model"; end
+                def tire_document_type;   "my_namespace/my_model"; end
                 def to_indexed_json; "{}";                    end
               end
             end

--- a/test/unit/model_persistence_test.rb
+++ b/test/unit/model_persistence_test.rb
@@ -36,9 +36,9 @@ module Tire
 
         end
 
-        should "have document_type" do
-          assert_equal 'persistent_article', PersistentArticle.document_type
-          assert_equal 'persistent_article', PersistentArticle.new(:title => 'Test').document_type
+        should "have tire_document_type" do
+          assert_equal 'persistent_article', PersistentArticle.tire_document_type
+          assert_equal 'persistent_article', PersistentArticle.new(:title => 'Test').tire_document_type
         end
 
         should "allow to define property" do

--- a/test/unit/model_search_test.rb
+++ b/test/unit/model_search_test.rb
@@ -36,7 +36,7 @@ module Tire
           assert_respond_to ::ModelWithIndexCallbacks, :after_update_elasticsearch_index
         end
 
-        should "limit searching in index for documents matching the model 'document_type'" do
+        should "limit searching in index for documents matching the model 'tire_document_type'" do
           Tire::Search::Search.
             expects(:new).
             with('active_model_articles', { :type => 'active_model_article' }).
@@ -50,7 +50,7 @@ module Tire
         should "search in custom name" do
           first  = 'custom-index-name'
           second = 'another-custom-index-name'
-          expected_options = { :type => ActiveModelArticleWithCustomIndexName.document_type }
+          expected_options = { :type => ActiveModelArticleWithCustomIndexName.tire_document_type }
 
           Tire::Search::Search.expects(:new).with(first, expected_options).returns(@stub).twice
           ActiveModelArticleWithCustomIndexName.index_name first
@@ -90,7 +90,7 @@ module Tire
         should "allow to pass custom index name" do
           Tire::Search::Search.
             expects(:new).
-            with('custom_index', { :type => ActiveModelArticle.document_type }).
+            with('custom_index', { :type => ActiveModelArticle.tire_document_type }).
             returns(@stub).
             twice
 


### PR DESCRIPTION
we have an association named `document_type` which conflicts in retire naming module, so replace `document_type` to `retire_document_type`
