### PR TITLE
Edge case for respond_to? when serializing items

### DIFF
--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -364,7 +364,7 @@ module Tire
       wrapper = options[:wrapper] || Configuration.wrapper
       if wrapper == Hash then h
       else
-        return nil if (h['exists'] || h['found']) == false
+        return nil if (h['exists'] == false || h['found'] == false)
         document = h['_source'] || h['fields'] || {}
         document.update('id' => h['_id'], '_type' => h['_type'], '_index' => h['_index'], '_version' => h['_version'])
         wrapper.new(document)

--- a/lib/tire/results/item.rb
+++ b/lib/tire/results/item.rb
@@ -27,7 +27,7 @@ module Tire
       end
 
       def respond_to?(method_name, include_private = false)
-        @attributes.has_key?(method_name.to_sym) || super
+        (@attributes || {}).has_key?(method_name.to_sym) || super
       end
 
       def [](key)

--- a/test/unit/results_item_test.rb
+++ b/test/unit/results_item_test.rb
@@ -82,6 +82,10 @@ module Tire
         assert @document.respond_to?(:title, true)
       end
 
+      should "not raise errors when unserializing" do
+        assert_nothing_raised { YAML.load(YAML.dump(@document)) }
+      end
+
       should "return nil for non-existing keys/methods" do
         assert_nothing_raised { @document.whatever }
         assert_nil @document.whatever


### PR DESCRIPTION
I found an issue with class `Tire::Result::Item` when the object is serialized. The current version cannot be deserialized by (for instance) Psych, since it uses [`Class#allocate`](https://github.com/tenderlove/psych/blob/master/lib/psych/visitors/to_ruby.rb#L47) instead of 'Class#new`.

In that case `#initialize` is not called and `@attributes` is nil.

Hope this will get merged.
