### PR TITLE
Cast field data that is wrapped in an array from elasticsearch v1

### DIFF
--- a/lib/tire/model/persistence/attributes.rb
+++ b/lib/tire/model/persistence/attributes.rb
@@ -129,6 +129,9 @@ module Tire
           # instances and automatically convert UTC formatted strings to Time.
           #
           def __cast_value(name, value)
+            klass = self.class.property_types[name.to_sym]
+            # elasticsearch v1 returns field data wrapped in an array
+            value = value.first unless klass.is_a?(Array) || value.nil? || !value.is_a?(Array)
             case
 
               when klass = self.class.property_types[name.to_sym]

--- a/lib/tire/model/persistence/attributes.rb
+++ b/lib/tire/model/persistence/attributes.rb
@@ -129,9 +129,9 @@ module Tire
           # instances and automatically convert UTC formatted strings to Time.
           #
           def __cast_value(name, value)
-            klass = self.class.property_types[name.to_sym]
+            default = self.class.property_defaults[name.to_sym]
             # elasticsearch v1 returns field data wrapped in an array
-            value = value.first unless klass.is_a?(Array) || value.nil? || !value.is_a?(Array)
+            value = value.first unless !value.is_a?(Array) || default.is_a?(Array) || value.nil?
             case
 
               when klass = self.class.property_types[name.to_sym]


### PR DESCRIPTION
Elasticsearch v1 returns field values as an array when using `fields` option.

https://github.com/elasticsearch/elasticsearch/issues/4542
