### PR TITLE
Improve logger & general string concat performance

### DIFF
--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -93,7 +93,7 @@ module Tire
       end
 
       url  = "#{self.url}/#{type}/_mapping"
-      url += "?#{params.to_param}" unless params.empty?
+      url << "?#{params.to_param}" unless params.empty?
 
       payload = { type => mapping }.to_json
 
@@ -382,7 +382,7 @@ module Tire
 
       type      = Utils.escape(type)
       url       = "#{self.url}/#{type}/#{Utils.escape(id)}/_update"
-      url      += "?#{options.to_param}" unless options.keys.empty?
+      url      << "?#{options.to_param}" unless options.keys.empty?
       @response = Configuration.client.post url, MultiJson.encode(payload)
       MultiJson.decode(@response.body)
 

--- a/lib/tire/logger.rb
+++ b/lib/tire/logger.rb
@@ -26,11 +26,11 @@ module Tire
       # curl -X POST ....
       #
       content  = "# #{time}"
-      content += " [#{endpoint}]"
-      content += " (#{params.inspect})" if params
-      content += "\n#\n"
-      content += curl
-      content += "\n\n"
+      content << " [#{endpoint}]"
+      content << " (#{params.inspect})" if params
+      content << "\n#\n"
+      content << curl
+      content << "\n\n"
       write content
     end
 
@@ -44,11 +44,11 @@ module Tire
       # }
       #
       content  = "# #{time}"
-      content += " [#{status}]"
-      content += " (#{took} msec)" if took
-      content += "\n#\n" unless json.to_s !~ /\S/
-      json.to_s.each_line { |line| content += "# #{line}" } unless json.to_s !~ /\S/
-      content += "\n\n"
+      content << " [#{status}]"
+      content << " (#{took} msec)" if took
+      content << "\n#\n" unless json.to_s !~ /\S/
+      json.to_s.each_line { |line| content << "# #{line}" } unless json.to_s !~ /\S/
+      content << "\n\n"
       write content
     end
 

--- a/test/integration/reindex_test.rb
+++ b/test/integration/reindex_test.rb
@@ -41,7 +41,7 @@ module Tire
 
       should "transform documents with a passed lambda" do
         Tire.index('reindex-test').reindex 'reindex-test-new', transform: lambda { |document|
-                                                                            document[:title] += 'UPDATED'
+                                                                            document[:title] << 'UPDATED'
                                                                             document
                                                                           }
 

--- a/test/unit/logger_test.rb
+++ b/test/unit/logger_test.rb
@@ -105,9 +105,9 @@ module Tire
           # 2011-03-19 11:00:00:000 [200 OK] (4 msec)
           #
         log;
-        # log += json.split.map { |line| "# #{line}" }.join("\n")
-        json.each_line { |line| log += "# #{line}" }
-        log += "\n\n"
+        # log << json.split.map { |line| "# #{line}" }.join("\n")
+        json.each_line { |line| log << "# #{line}" }
+        log << "\n\n"
         @logger.expects(:write).with do |payload|
           payload =~ Regexp.new( Regexp.escape('2011-03-19 11:00:00') )
           payload =~ Regexp.new( Regexp.escape('[200 OK]') )


### PR DESCRIPTION
Dramatically improves the performance of the code where strings are concatenated, by changing the "+=" for "<<". 
Sample profiling of [line 50 on logger.rb](https://github.com/karmi/retire/blob/0512cc5e3528d9ab4c709f58a3ffb2e20c1f4196/lib/tire/logger.rb#L50) with a 20,000 lines json response from ElasticSearch:

```
Before the change
99.74%  48.04 seconds String#each_line

After the change
74.91%  0.11 seconds String#each_line
```

Fixes #155
