### PR TITLE
`to_curl` is private. Fixes karmi/retire#962

### DIFF
--- a/lib/tire/delete_by_query.rb
+++ b/lib/tire/delete_by_query.rb
@@ -20,7 +20,7 @@ module Tire
     def perform
       @response = Configuration.client.delete url
       if @response.failure?
-        STDERR.puts "[REQUEST FAILED] #{self.to_curl}\n"
+        STDERR.puts "[REQUEST FAILED] #{to_curl}\n"
         raise DeleteByQueryRequestFailed, @response.to_s
       end
       @json = MultiJson.decode(@response.body)


### PR DESCRIPTION
Prevent `NoMethodError` on failed `DeleteByQuery#perform`
