### PR TITLE
Script based order

### DIFF
--- a/lib/tire/search/sort.rb
+++ b/lib/tire/search/sort.rb
@@ -12,6 +12,17 @@ module Tire
         self
       end
 
+      def by_script(script, type, order)
+        @value << {
+            _script: {
+              script: script,
+              type: type.to_s,
+              order: order.to_s
+            }
+          }
+        self
+      end
+
       def to_ary
         @value
       end


### PR DESCRIPTION
It allows to use this clause for generate this JSON, it allows to order
by a calculated field, by example:
sort do
by_script "sin(doc['id'].value + #{day_r})", :number, :asc
end

Will generate this JSON

{
_script: {
script: "sin(doc['id'].value + #{day_r})",
type: "number",
order: "asc"
}
}
