### PR TITLE
add preference in the list of search parameters

### DIFF
--- a/lib/tire/configuration.rb
+++ b/lib/tire/configuration.rb
@@ -6,6 +6,23 @@ module Tire
       @url = (value ? value.to_s.gsub(%r|/*$|, '') : nil) || @url || ENV['ELASTICSEARCH_URL'] || "http://localhost:9200"
     end
 
+    def self.urls(values=nil)
+      unless values.nil?
+        @urls = values
+        @url = @urls.first
+      end
+      @urls
+    end
+
+    def self.shift_server
+      unless @urls.nil? or @urls.empty?
+        @urls.shift
+        @url = @urls.first
+        STDERR.puts "[INFO] Switching to server #{self.url}"
+        @url
+      end
+    end
+
     def self.client(klass=nil)
       @client = klass || @client || HTTP::Client::RestClient
     end

--- a/lib/tire/dsl.rb
+++ b/lib/tire/dsl.rb
@@ -22,7 +22,7 @@ module Tire
 
         # Extract URL parameters from payload
         #
-        search_params = %w| search_type routing scroll from size timeout |
+        search_params = %w| search_type routing scroll from size timeout preference |
 
         search_options = search_params.inject({}) do |sum,item|
           if param = (payload.delete(item) || payload.delete(item.to_sym))

--- a/lib/tire/index.rb
+++ b/lib/tire/index.rb
@@ -254,6 +254,12 @@ module Tire
           retry
         else
           STDERR.puts "[ERROR] Too many exceptions occured, giving up. The HTTP response was: #{error.message}"
+
+          unless Configuration.shift_server.nil?
+            count = 0
+            retry
+          end
+
           raise if options[:raise]
         end
 

--- a/lib/tire/search.rb
+++ b/lib/tire/search.rb
@@ -139,7 +139,15 @@ module Tire
       end
 
       def perform
-        @response = Configuration.client.get(self.url + self.params, self.to_json)
+        begin
+          @response = Configuration.client.get(self.url + self.params, self.to_json)
+        rescue Errno::ECONNREFUSED
+          unless Configuration.shift_server.nil?
+            retry
+          end
+          raise
+        end
+
         if @response.failure?
           STDERR.puts "[REQUEST FAILED] #{self.to_curl}\n"
           raise SearchRequestFailed, @response.to_s

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -77,6 +77,15 @@ module Tire
         assert_equal          'http://localhost:9200', Configuration.url
         assert_equal          HTTP::Client::RestClient, Configuration.client
       end
+
+      should "allow multiple urls" do
+        urls = [
+          "http://localhost:9200",
+          "http://localhost:9201"
+        ]
+        Configuration.urls    urls
+        assert_equal          urls.first, Configuration.url
+      end
     end
 
   end


### PR DESCRIPTION
Add the preference feature described here:
http://www.elastic.co/guide/en/elasticsearch/reference/1.4/search-request-preference.html

Note that 2 unit tests fail.

``` bash
bundle exec rake test:unit
```

```
ERROR (0:00:02.419) test_: Collection with ActiveModel::Serializers should be serializable. 
      uninitialized constant ActiveModel::ArraySerializerSupport
    @ test/unit/results_collection_test.rb:402:in `block (3 levels) in <class:ResultsCollectionTest>'
      /var/lib/gems/2.1.0/gems/shoulda-context-1.2.1/lib/shoulda/context/context.rb:436:in `instance_exec'
      /var/lib/gems/2.1.0/gems/shoulda-context-1.2.1/lib/shoulda/context/context.rb:436:in `block in run_current_setup_blocks'
      /var/lib/gems/2.1.0/gems/shoulda-context-1.2.1/lib/shoulda/context/context.rb:434:in `each'
      /var/lib/gems/2.1.0/gems/shoulda-context-1.2.1/lib/shoulda/context/context.rb:434:in `run_current_setup_blocks'
      /var/lib/gems/2.1.0/gems/shoulda-context-1.2.1/lib/shoulda/context/context.rb:411:in `block in create_test_from_should_hash'
      /var/lib/gems/2.1.0/gems/mocha-0.14.0/lib/mocha/integration/mini_test/version_2112_to_320.rb:40:in `run'

ERROR (0:00:02.442) test_: Item with ActiveModel::Serializers should be serializable. 
      undefined method `attribute' for MyItemSerializer:Class
    @ test/unit/results_item_test.rb:195:in `<class:MyItemSerializer>'
      test/unit/results_item_test.rb:194:in `block (3 levels) in <class:ResultsItemTest>'
      /var/lib/gems/2.1.0/gems/shoulda-context-1.2.1/lib/shoulda/context/context.rb:436:in `instance_exec'
      /var/lib/gems/2.1.0/gems/shoulda-context-1.2.1/lib/shoulda/context/context.rb:436:in `block in run_current_setup_blocks'
      /var/lib/gems/2.1.0/gems/shoulda-context-1.2.1/lib/shoulda/context/context.rb:434:in `each'
      /var/lib/gems/2.1.0/gems/shoulda-context-1.2.1/lib/shoulda/context/context.rb:434:in `run_current_setup_blocks'
      /var/lib/gems/2.1.0/gems/shoulda-context-1.2.1/lib/shoulda/context/context.rb:411:in `block in create_test_from_should_hash'
      /var/lib/gems/2.1.0/gems/mocha-0.14.0/lib/mocha/integration/mini_test/version_2112_to_320.rb:40:in `run'
```
